### PR TITLE
Add Classifier Timeout

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Views\AskAFriendNotifier.xaml.cs">
       <DependentUpon>AskAFriendNotifier.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\StillThereViewModel.cs" />
     <Compile Include="Views\Centerpiece.xaml.cs">
       <DependentUpon>Centerpiece.xaml</DependentUpon>
     </Compile>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -198,6 +198,9 @@
     <Compile Include="Views\StartButton.xaml.cs">
       <DependentUpon>StartButton.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\StillThereModal.xaml.cs">
+      <DependentUpon>StillThereModal.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SubjectViewer.xaml.cs">
       <DependentUpon>SubjectViewer.xaml</DependentUpon>
     </Compile>
@@ -333,6 +336,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Styles\RoundedProgressBar.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\StillThereModal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -175,6 +175,7 @@
       <DependentUpon>AskAFriendNotifier.xaml</DependentUpon>
     </Compile>
     <Compile Include="ViewModels\StillThereViewModel.cs" />
+    <Compile Include="ViewModels\ViewModelBase.cs" />
     <Compile Include="Views\Centerpiece.xaml.cs">
       <DependentUpon>Centerpiece.xaml</DependentUpon>
     </Compile>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Models\NotificationRequest.cs" />
     <Compile Include="ViewModels\NotificationsViewModel.cs" />
+    <Compile Include="Models\CircularProgress.cs" />
     <Compile Include="ViewModels\LevelerViewModel.cs" />
     <Compile Include="Views\AskAFriendButtons.xaml.cs">
       <DependentUpon>AskAFriendButtons.xaml</DependentUpon>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/CircularProgress.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/CircularProgress.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+
+namespace GalaxyZooTouchTable.Models
+{
+    public class CircularProgress : INotifyPropertyChanged
+    {
+        private readonly int Radius;
+
+        private bool _isLargeArc;
+        public bool IsLargeArc
+        {
+            get => _isLargeArc;
+            set
+            {
+                _isLargeArc = value;
+                OnPropertyRaised("LargeArc");
+            }
+        }
+
+        private Size _arcSize;
+        public Size ArcSize
+        {
+            get => _arcSize;
+            set
+            {
+                _arcSize = value;
+                OnPropertyRaised("ArcSize");
+            }
+        }
+
+        private Point _startPoint = new Point();
+        public Point StartPoint
+        {
+            get => _startPoint;
+            set
+            {
+                _startPoint = value;
+                OnPropertyRaised("StartPoint");
+            }
+        }
+
+        private Point _arcPoint;
+        public Point ArcPoint
+        {
+            get => _arcPoint;
+            set
+            {
+                _arcPoint = value;
+                OnPropertyRaised("ArcPoint");
+            }
+        }
+
+        public CircularProgress(int radius)
+        {
+            Radius = radius;
+        }
+
+        private Point ComputeCartesianCoordinate(double angle, double radius)
+        {
+            double angleRad = (Math.PI / 180.0) * (angle - 90);
+            double x = radius * Math.Cos(angleRad);
+            double y = radius * Math.Sin(angleRad);
+            return new Point(x, y);
+        }
+
+        public void RenderArc(int Percentage)
+        {
+            int Angle = -(Percentage * 360) / 100;
+            StartPoint = new Point(Radius, 0);
+            Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
+            endPoint.X += Radius;
+            endPoint.Y += Radius;
+
+            bool largeArc = -Angle > 180.0;
+
+            Size outerArcSize = new Size(Radius, Radius);
+
+            if (StartPoint.X == Math.Round(endPoint.X) && StartPoint.Y == Math.Round(endPoint.Y))
+                endPoint.X += 0.01;
+
+            ArcPoint = endPoint;
+            ArcSize = outerArcSize;
+            IsLargeArc = largeArc;
+        }
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyRaised(string propertyname)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyname));
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -258,7 +258,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (StillThereTimer != null)
             {
-                StillThereTimer.Interval = new System.TimeSpan(0, 4, 30);
+                StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
                 StillThereTimer.Start();
             }
             if (StillThere.Visible) { StillThere.Visible = false; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -15,7 +15,7 @@ using System.Windows.Threading;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
-    public class ClassificationPanelViewModel : INotifyPropertyChanged
+    public class ClassificationPanelViewModel : ViewModelBase
     {
         public ObservableCollection<TableUser> AllUsers { get; set; }
         public DispatcherTimer StillThereTimer { get; set; } = new DispatcherTimer();
@@ -41,115 +41,81 @@ namespace GalaxyZooTouchTable.ViewModels
         private NotificationsViewModel _notifications;
         public NotificationsViewModel Notifications
         {
-            get { return _notifications; }
-            set
-            {
-                _notifications = value;
-                OnPropertyRaised("Notifications");
-            }
+            get => _notifications;
+            set => SetProperty(ref _notifications, value);
         }
 
         private StillThereViewModel _stillThere;
         public StillThereViewModel StillThere
         {
-            get { return _stillThere; }
-            set
-            {
-                _stillThere = value;
-                OnPropertyRaised("StillThere");
-            }
+            get => _stillThere;
+            set => SetProperty(ref _stillThere, value);
         }
 
         private int _totalVotes = 0;
         public int TotalVotes
         {
-            get { return _totalVotes; }
-            set
-            {
-                _totalVotes = value;
-                OnPropertyRaised("TotalVotes");
-            }
+            get => _totalVotes;
+            set => SetProperty(ref _totalVotes, value);
         }
 
         private ClassifierViewEnum _currentView = ClassifierViewEnum.SubjectView;
         public ClassifierViewEnum CurrentView
         {
-            get { return _currentView; }
-            set
-            {
-                _currentView = value;
-                OnPropertyRaised("CurrentView");
-            }
+            get => _currentView;
+            set => SetProperty(ref _currentView, value);
         } 
 
         private bool _closeConfirmationVisible = false;
         public bool CloseConfirmationVisible
         {
-            get { return _closeConfirmationVisible; }
-            set
-            {
-                _closeConfirmationVisible = value;
-                OnPropertyRaised("CloseConfirmationVisible");
-            }
+            get => _closeConfirmationVisible;
+            set => SetProperty(ref _closeConfirmationVisible, value);
         }
 
         private bool _classifierOpen = false;
         public bool ClassifierOpen
         {
-            get { return _classifierOpen; }
-            set
-            {
-                _classifierOpen = value;
-                OnPropertyRaised("ClassifierOpen");
-            }
+            get => _classifierOpen;
+            set => SetProperty(ref _classifierOpen, value);
         }
 
         private Annotation _currentAnnotation;
         public Annotation CurrentAnnotation
         {
-            get { return _currentAnnotation; }
+            get => _currentAnnotation;
             set
             {
-                _currentAnnotation = value;
                 CanSendClassification = value != null;
-                OnPropertyRaised("CurrentAnnotation");
+                SetProperty(ref _currentAnnotation, value);
             }
         }
 
         private bool _canSendClassification = false;
         public bool CanSendClassification
         {
-            get { return _canSendClassification; }
-            set
-            {
-                _canSendClassification = value;
-                OnPropertyRaised("CanSendClassification");
-            }
+            get => _canSendClassification;
+            set => SetProperty(ref _canSendClassification, value);
         }
 
         private string _subjectImageSource;
         public string SubjectImageSource
         {
-            get { return _subjectImageSource; }
-            set
-            {
-                _subjectImageSource = value;
-                OnPropertyRaised("SubjectImageSource");
-            }
+            get => _subjectImageSource;
+            set => SetProperty(ref _subjectImageSource, value);
         }
 
         private AnswerButton _selectedAnswer;
         public AnswerButton SelectedAnswer
         {
-            get { return _selectedAnswer; }
+            get => _selectedAnswer;
             set
             {
-                _selectedAnswer = value;
                 if (value != null)
                 {
                     ChooseAnswer(value);
                 }
-                OnPropertyRaised("SelectedAnswer");
+                SetProperty(ref _selectedAnswer, value);
             }
         }
 
@@ -413,18 +379,6 @@ namespace GalaxyZooTouchTable.ViewModels
                     TotalVotes += answerCount;
                 }
             }
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void OnPropertyRaised(string propertyname)
-        {
-            if (StillThereTimer != null && StillThereTimer.IsEnabled)
-            {
-                ResetTimer();
-            }
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyname));
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -258,7 +258,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (StillThereTimer != null)
             {
-                StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
+                StillThereTimer.Interval = new System.TimeSpan(0, 4, 30);
                 StillThereTimer.Start();
             }
             if (StillThere.Visible) { StillThere.Visible = false; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -49,6 +49,17 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
+        private StillThereViewModel _stillThere;
+        public StillThereViewModel StillThere
+        {
+            get { return _stillThere; }
+            set
+            {
+                _stillThere = value;
+                OnPropertyRaised("StillThere");
+            }
+        }
+
         private int _totalVotes = 0;
         public int TotalVotes
         {
@@ -155,6 +166,7 @@ namespace GalaxyZooTouchTable.ViewModels
             CurrentTaskIndex = workflow.FirstTask;
             Notifications = new NotificationsViewModel(user, allUsers, this);
             LevelerViewModel = new LevelerViewModel(user);
+            StillThere = new StillThereViewModel(this);
             ExamplesViewModel.PropertyChanged += ResetTimer;
             LevelerViewModel.PropertyChanged += ResetTimer;
 
@@ -197,10 +209,10 @@ namespace GalaxyZooTouchTable.ViewModels
             User.Active = true;
         }
 
-        private void OnCloseClassifier(object sender)
+        public void OnCloseClassifier(object sender = null)
         {
             Notifications.ClearNotifications(true);
-            StopTimer();
+            StillThereTimer = null;
             LevelerViewModel.IsOpen = false;
             ExamplesViewModel.IsOpen = true;
             ExamplesViewModel.SelectedExample = null;
@@ -260,18 +272,16 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void StartTimer()
         {
+            StillThereTimer = new DispatcherTimer();
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            ResetTimer();
-        }
-
-        private void StopTimer()
-        {
-            StillThereTimer.Stop();
+            StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
+            StillThereTimer.Start();
         }
 
         private void ShowStillThereModal(object sender, System.EventArgs e)
         {
-            System.Console.WriteLine("Show Modal Now");
+            StillThereTimer.Stop();
+            StillThere.Visible = true;
         }
 
         private void ChooseAnswer(AnswerButton button)
@@ -281,8 +291,12 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void ResetTimer()
         {
-            StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
-            StillThereTimer.Start();
+            if (StillThereTimer != null)
+            {
+                StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
+                StillThereTimer.Start();
+            }
+            if (StillThere.Visible) { StillThere.Visible = false; }
         }
 
         private void ResetTimer(object sender, PropertyChangedEventArgs e)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -274,8 +274,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             StillThereTimer = new DispatcherTimer();
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
-            StillThereTimer.Start();
+            ResetTimer();
         }
 
         private void ShowStillThereModal(object sender, System.EventArgs e)
@@ -293,7 +292,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (StillThereTimer != null)
             {
-                StillThereTimer.Interval = new System.TimeSpan(0, 0, 5);
+                StillThereTimer.Interval = new System.TimeSpan(0, 4, 30);
                 StillThereTimer.Start();
             }
             if (StillThere.Visible) { StillThere.Visible = false; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -289,7 +289,7 @@ namespace GalaxyZooTouchTable.ViewModels
             CurrentAnnotation = new Annotation(CurrentTaskIndex, button.Index);
         }
 
-        private void ResetTimer()
+        public void ResetTimer()
         {
             if (StillThereTimer != null)
             {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using GalaxyZooTouchTable.Utility;
 using System;
-using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -23,22 +22,14 @@ namespace GalaxyZooTouchTable.ViewModels
         public decimal CurrentSeconds
         {
             get => _currentSeconds;
-            set
-            {
-                _currentSeconds = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _currentSeconds, value);
         }
 
         private bool _isLargeArc;
         public bool IsLargeArc
         {
             get => _isLargeArc;
-            set
-            {
-                _isLargeArc = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _isLargeArc, value);
         }
 
         private bool _visible = false;
@@ -47,7 +38,6 @@ namespace GalaxyZooTouchTable.ViewModels
             get => _visible;
             set
             {
-                _visible = value;
                 if (value == true)
                 {
                     StartTimers();
@@ -55,7 +45,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 {
                     StopTimers();
                 }
-                OnPropertyChanged();
+                SetProperty(ref _visible, value);
             }
         }
 
@@ -63,66 +53,42 @@ namespace GalaxyZooTouchTable.ViewModels
         public Size ArcSize
         {
             get => _arcSize;
-            set
-            {
-                _arcSize = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _arcSize, value);
         }
 
         private Point _startPoint = new Point();
         public Point StartPoint
         {
-            get => _startPoint; 
-            set
-            {
-                _startPoint = value;
-                OnPropertyChanged();
-            }
+            get => _startPoint;
+            set => SetProperty(ref _startPoint, value);
         }
 
         private Point _arcPoint;
         public Point ArcPoint
         {
             get => _arcPoint;
-            set
-            {
-                _arcPoint = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _arcPoint, value);
         }
 
         private Thickness _margin;
         public Thickness Margin
         {
             get => _margin;
-            set
-            {
-                _margin = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _margin, value);
         }
 
         private double _width;
         public double Width
         {
             get => _width;
-            set
-            {
-                _width = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _width, value);
         }
 
         private double _height;
         public double Height
         {
             get => _height;
-            set
-            {
-                _height = value;
-                OnPropertyChanged();
-            }
+            set => SetProperty(ref _height, value);
         }
 
         public StillThereViewModel(ClassificationPanelViewModel classifier)
@@ -181,7 +147,6 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             CurrentSeconds--;
             decimal StartingSeconds = 30;
-            decimal test = CurrentSeconds / StartingSeconds;
             decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
             Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
             RenderArc();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -1,6 +1,7 @@
-﻿using GalaxyZooTouchTable.Utility;
+﻿using GalaxyZooTouchTable.Models;
+using GalaxyZooTouchTable.Utility;
 using System;
-using System.Windows;
+using System.ComponentModel;
 using System.Windows.Input;
 using System.Windows.Threading;
 
@@ -11,25 +12,23 @@ namespace GalaxyZooTouchTable.ViewModels
         public ClassificationPanelViewModel Classifier { get; set; }
         public DispatcherTimer SecondTimer { get; set; }
         public DispatcherTimer ThirtySecondTimer { get; set; }
-        public int Radius { get; set; } = 41;
-        public int Percentage { get; set; } = 100;
-        public int StrokeThickness { get; set; } = 4;
+        private int Percentage { get; set; } = 100;
 
         public ICommand CloseClassifier { get; set; }
         public ICommand CloseModal { get; set; }
+
+        private CircularProgress _circle;
+        public CircularProgress Circle
+        {
+            get => _circle;
+            set => SetProperty(ref _circle, value);
+        }
 
         private decimal _currentSeconds = 30;
         public decimal CurrentSeconds
         {
             get => _currentSeconds;
             set => SetProperty(ref _currentSeconds, value);
-        }
-
-        private bool _isLargeArc;
-        public bool IsLargeArc
-        {
-            get => _isLargeArc;
-            set => SetProperty(ref _isLargeArc, value);
         }
 
         private bool _visible = false;
@@ -49,53 +48,18 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private Size _arcSize;
-        public Size ArcSize
-        {
-            get => _arcSize;
-            set => SetProperty(ref _arcSize, value);
-        }
-
-        private Point _startPoint = new Point();
-        public Point StartPoint
-        {
-            get => _startPoint;
-            set => SetProperty(ref _startPoint, value);
-        }
-
-        private Point _arcPoint;
-        public Point ArcPoint
-        {
-            get => _arcPoint;
-            set => SetProperty(ref _arcPoint, value);
-        }
-
-        private Thickness _margin;
-        public Thickness Margin
-        {
-            get => _margin;
-            set => SetProperty(ref _margin, value);
-        }
-
-        private double _width;
-        public double Width
-        {
-            get => _width;
-            set => SetProperty(ref _width, value);
-        }
-
-        private double _height;
-        public double Height
-        {
-            get => _height;
-            set => SetProperty(ref _height, value);
-        }
-
         public StillThereViewModel(ClassificationPanelViewModel classifier)
         {
             Classifier = classifier;
+            Circle = new CircularProgress(41);
             LoadCommands();
-            RenderArc();
+            Circle.RenderArc(Percentage);
+            Circle.PropertyChanged += CircleChanged;
+        }
+
+        private void CircleChanged(object sender, PropertyChangedEventArgs e)
+        {
+            OnPropertyChanged("Circle");
         }
 
         private void LoadCommands()
@@ -128,7 +92,7 @@ namespace GalaxyZooTouchTable.ViewModels
             ThirtySecondTimer.Tick += new System.EventHandler(ThirtySecondsElapsed);
             ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 31);
             ThirtySecondTimer.Start();
-            RenderArc();
+            Circle.RenderArc(Percentage);
         }
 
         private void StopTimers()
@@ -149,39 +113,7 @@ namespace GalaxyZooTouchTable.ViewModels
             decimal StartingSeconds = 30;
             decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
             Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
-            RenderArc();
-        }
-
-        private Point ComputeCartesianCoordinate(double angle, double radius)
-        {
-            double angleRad = (Math.PI / 180.0) * (angle - 90);
-            double x = radius * Math.Cos(angleRad);
-            double y = radius * Math.Sin(angleRad);
-            return new Point(x, y);
-        }
-
-        public void RenderArc()
-        {
-            int Angle = -(Percentage * 360) / 100;
-            StartPoint = new Point(Radius, 0);
-            Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
-            endPoint.X += Radius;
-            endPoint.Y += Radius;
-
-            Width = Radius * 2 + StrokeThickness + 10;
-            Height = Radius * 2 + StrokeThickness + 10;
-            Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
-
-            bool largeArc = -Angle > 180.0;
-
-            Size outerArcSize = new Size(Radius, Radius);
-
-            if (StartPoint.X == Math.Round(endPoint.X) && StartPoint.Y == Math.Round(endPoint.Y))
-                endPoint.X += 0.01;
-
-            ArcPoint = endPoint;
-            ArcSize = outerArcSize;
-            IsLargeArc = largeArc;
+            Circle.RenderArc(Percentage);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace GalaxyZooTouchTable.ViewModels
+{
+    public class StillThereViewModel : INotifyPropertyChanged
+    {
+        public ClassificationPanelViewModel Classifier { get; set; }
+        public DispatcherTimer SecondTimer { get; set; }
+        public DispatcherTimer ThirtySecondTimer { get; set; }
+        public int Radius { get; set; } = 41;
+        public int Percentage { get; set; } = 100;
+        public int StrokeThickness { get; set; } = 4;
+
+        private decimal _currentSeconds = 30;
+        public decimal CurrentSeconds
+        {
+            get { return _currentSeconds; }
+            set
+            {
+                _currentSeconds = value;
+                OnPropertyRaised("CurrentSeconds");
+            }
+        }
+
+        private bool _isLargeArc;
+        public bool IsLargeArc
+        {
+            get { return _isLargeArc; }
+            set
+            {
+                _isLargeArc = value;
+                OnPropertyRaised("IsLargeArc");
+            }
+        }
+
+        private bool _visible = false;
+        public bool Visible
+        {
+            get { return _visible; }
+            set
+            {
+                _visible = value;
+                if (value == true)
+                {
+                    StartTimers();
+                } else
+                {
+                    StopTimers();
+                }
+                OnPropertyRaised("Visible");
+            }
+        }
+
+        private Size _arcSize;
+        public Size ArcSize
+        {
+            get { return _arcSize; }
+            set
+            {
+                _arcSize = value;
+                OnPropertyRaised("ArcSize");
+            }
+        }
+
+        private Point _startPoint = new Point();
+        public Point StartPoint
+        {
+            get { return _startPoint; }
+            set
+            {
+                _startPoint = value;
+                OnPropertyRaised("StartPoint");
+            }
+        }
+
+        private Point _arcPoint;
+        public Point ArcPoint
+        {
+            get { return _arcPoint; }
+            set
+            {
+                _arcPoint = value;
+                OnPropertyRaised("ArcPoint");
+            }
+        }
+
+        private Thickness _margin;
+        public Thickness Margin
+        {
+            get { return _margin; }
+            set
+            {
+                _margin = value;
+                OnPropertyRaised("Margin");
+            }
+        }
+
+        private double _width;
+        public double Width
+        {
+            get { return _width; }
+            set
+            {
+                _width = value;
+                OnPropertyRaised("Width");
+            }
+        }
+
+        private double _height;
+        public double Height
+        {
+            get { return _height; }
+            set
+            {
+                _height = value;
+                OnPropertyRaised("Height");
+            }
+        }
+
+        public StillThereViewModel(ClassificationPanelViewModel classifier)
+        {
+            Classifier = classifier;
+            RenderArc();
+        }
+
+        private void StartTimers()
+        {
+            CurrentSeconds = 30;
+            Percentage = 100;
+            SecondTimer = new DispatcherTimer();
+            SecondTimer.Tick += new System.EventHandler(OneSecondElapsed);
+            SecondTimer.Interval = new System.TimeSpan(0, 0, 1);
+            SecondTimer.Start();
+
+            ThirtySecondTimer = new DispatcherTimer();
+            ThirtySecondTimer.Tick += new System.EventHandler(ThirtySecondsElapsed);
+            ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 31);
+            ThirtySecondTimer.Start();
+            RenderArc();
+        }
+
+        private void StopTimers()
+        {
+            SecondTimer.Stop();
+            ThirtySecondTimer.Stop();
+        }
+
+        private void ThirtySecondsElapsed(object sender, EventArgs e)
+        {
+            Classifier.OnCloseClassifier();
+            Visible = false;
+        }
+
+        private void OneSecondElapsed(object sender, System.EventArgs e)
+        {
+            CurrentSeconds--;
+            decimal StartingSeconds = 30;
+            decimal test = CurrentSeconds / StartingSeconds;
+            decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
+            Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
+            RenderArc();
+        }
+
+        private Point ComputeCartesianCoordinate(double angle, double radius)
+        {
+            double angleRad = (Math.PI / 180.0) * (angle - 90);
+            double x = radius * Math.Cos(angleRad);
+            double y = radius * Math.Sin(angleRad);
+            return new Point(x, y);
+        }
+
+        public void RenderArc()
+        {
+            int Angle = -(Percentage * 360) / 100;
+            StartPoint = new Point(Radius, 0);
+            Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
+            endPoint.X += Radius;
+            endPoint.Y += Radius;
+
+            Width = Radius * 2 + StrokeThickness + 10;
+            Height = Radius * 2 + StrokeThickness + 10;
+            Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
+
+            bool largeArc = -Angle > 180.0;
+
+            Size outerArcSize = new Size(Radius, Radius);
+
+            if (StartPoint.X == Math.Round(endPoint.X) && StartPoint.Y == Math.Round(endPoint.Y))
+                endPoint.X += 0.01;
+
+            ArcPoint = endPoint;
+            ArcSize = outerArcSize;
+            IsLargeArc = largeArc;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyRaised(string propertyname)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyname));
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿using GalaxyZooTouchTable.Utility;
+using System;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Threading;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
-    public class StillThereViewModel : INotifyPropertyChanged
+    public class StillThereViewModel : ViewModelBase
     {
         public ClassificationPanelViewModel Classifier { get; set; }
         public DispatcherTimer SecondTimer { get; set; }
@@ -14,32 +16,35 @@ namespace GalaxyZooTouchTable.ViewModels
         public int Percentage { get; set; } = 100;
         public int StrokeThickness { get; set; } = 4;
 
+        public ICommand CloseClassifier { get; set; }
+        public ICommand CloseModal { get; set; }
+
         private decimal _currentSeconds = 30;
         public decimal CurrentSeconds
         {
-            get { return _currentSeconds; }
+            get => _currentSeconds;
             set
             {
                 _currentSeconds = value;
-                OnPropertyRaised("CurrentSeconds");
+                OnPropertyChanged();
             }
         }
 
         private bool _isLargeArc;
         public bool IsLargeArc
         {
-            get { return _isLargeArc; }
+            get => _isLargeArc;
             set
             {
                 _isLargeArc = value;
-                OnPropertyRaised("IsLargeArc");
+                OnPropertyChanged();
             }
         }
 
         private bool _visible = false;
         public bool Visible
         {
-            get { return _visible; }
+            get => _visible;
             set
             {
                 _visible = value;
@@ -50,80 +55,98 @@ namespace GalaxyZooTouchTable.ViewModels
                 {
                     StopTimers();
                 }
-                OnPropertyRaised("Visible");
+                OnPropertyChanged();
             }
         }
 
         private Size _arcSize;
         public Size ArcSize
         {
-            get { return _arcSize; }
+            get => _arcSize;
             set
             {
                 _arcSize = value;
-                OnPropertyRaised("ArcSize");
+                OnPropertyChanged();
             }
         }
 
         private Point _startPoint = new Point();
         public Point StartPoint
         {
-            get { return _startPoint; }
+            get => _startPoint; 
             set
             {
                 _startPoint = value;
-                OnPropertyRaised("StartPoint");
+                OnPropertyChanged();
             }
         }
 
         private Point _arcPoint;
         public Point ArcPoint
         {
-            get { return _arcPoint; }
+            get => _arcPoint;
             set
             {
                 _arcPoint = value;
-                OnPropertyRaised("ArcPoint");
+                OnPropertyChanged();
             }
         }
 
         private Thickness _margin;
         public Thickness Margin
         {
-            get { return _margin; }
+            get => _margin;
             set
             {
                 _margin = value;
-                OnPropertyRaised("Margin");
+                OnPropertyChanged();
             }
         }
 
         private double _width;
         public double Width
         {
-            get { return _width; }
+            get => _width;
             set
             {
                 _width = value;
-                OnPropertyRaised("Width");
+                OnPropertyChanged();
             }
         }
 
         private double _height;
         public double Height
         {
-            get { return _height; }
+            get => _height;
             set
             {
                 _height = value;
-                OnPropertyRaised("Height");
+                OnPropertyChanged();
             }
         }
 
         public StillThereViewModel(ClassificationPanelViewModel classifier)
         {
             Classifier = classifier;
+            LoadCommands();
             RenderArc();
+        }
+
+        private void LoadCommands()
+        {
+            CloseClassifier = new CustomCommand(OnCloseClassifier);
+            CloseModal = new CustomCommand(OnCloseModal);
+        }
+
+        private void OnCloseClassifier(object sender)
+        {
+            Classifier.OnCloseClassifier();
+        }
+
+        private void OnCloseModal(object sender)
+        {
+            Visible = false;
+            Classifier.ResetTimer();
         }
 
         private void StartTimers()
@@ -194,14 +217,6 @@ namespace GalaxyZooTouchTable.ViewModels
             ArcPoint = endPoint;
             ArcSize = outerArcSize;
             IsLargeArc = largeArc;
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void OnPropertyRaised(string propertyname)
-        {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyname));
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelBase.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace GalaxyZooTouchTable.ViewModels
@@ -10,6 +11,15 @@ namespace GalaxyZooTouchTable.ViewModels
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(storage, value))
+                return false;
+            storage = value;
+            this.OnPropertyChanged(propertyName);
+            return true;
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelBase.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelBase.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace GalaxyZooTouchTable.ViewModels
+{
+    public abstract class ViewModelBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -49,7 +49,7 @@
             Visibility="{Binding Visible, Converter={StaticResource BoolToVis}, FallbackValue=Hidden}"
             HorizontalAlignment="Left"
             VerticalAlignment="Bottom"
-            Panel.ZIndex="2"/>
+            Panel.ZIndex="1"/>
 
         <Border
             Background="{StaticResource DarkGrayColor}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -43,6 +43,8 @@
             Margin="242,0,0,0"
             Width="42.7"/>
 
+        <Views:StillThereModal Panel.ZIndex="2"/>
+
         <Border
             Background="{StaticResource DarkGrayColor}"
             CornerRadius="2.85"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -43,7 +43,13 @@
             Margin="242,0,0,0"
             Width="42.7"/>
 
-        <Views:StillThereModal Panel.ZIndex="2"/>
+        <Views:StillThereModal
+            DataContext="{Binding StillThere}"
+            Margin="108,2,0,0"
+            Visibility="{Binding Visible, Converter={StaticResource BoolToVis}, FallbackValue=Hidden}"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Bottom"
+            Panel.ZIndex="2"/>
 
         <Border
             Background="{StaticResource DarkGrayColor}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationSummary.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationSummary.xaml
@@ -44,7 +44,7 @@
             ItemsSource="{Binding CurrentAnswers}"
             Margin="85,70,0,0"
             ScrollViewer.VerticalScrollBarVisibility="Disabled"
-            SelectedItem="{Binding SelectedItem}"
+            SelectedItem="{Binding SelectedAnswer}"
             VerticalAlignment="Top"
             Width="217">
             <ListView.ItemContainerStyle>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -46,11 +46,9 @@
                     Background="{StaticResource DarkGrayColor}"/>
 
                 <TextBlock
+                    Style="{StaticResource CommonType}"
                     Text="Still there?"
-                    Foreground="White"
                     Margin="16,43.9,0,0"
-                    FontWeight="Bold"
-                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
                     FontSize="19"/>
 
                 <TextBlock

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -3,13 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:GalaxyZooTouchTable.Views"
              xmlns:fa="http://schemas.fontawesome.io/icons/"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              mc:Ignorable="d" 
-             Height="291"
-             Width="312"
-             Background="#343438"
              d:DesignHeight="450" d:DesignWidth="800">
 
     <UserControl.Resources>
@@ -19,129 +15,132 @@
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
     </UserControl.Resources>
-    
-    <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
-        <Grid>
-            <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
 
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
-                <!--<i:Interaction.Triggers>
-                    <i:EventTrigger EventName="TouchUp">
-                        <i:InvokeCommandAction Command="{Binding ShowCloseConfirmation}"/>
-                    </i:EventTrigger>
-                </i:Interaction.Triggers>-->
+    <Border CornerRadius="3" Height="291" Width="312" Background="#F2343438">
+        <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
+            <Grid>
+                <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
+
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="TouchUp">
+                            <i:InvokeCommandAction Command="{Binding CloseModal}"/>
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
+                    <TextBlock
+                        FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                        FontSize="10"
+                        Foreground="White"
+                        Margin="5,0"
+                        Text="Cancel"/>
+                    <fa:ImageAwesome
+                        Foreground="White"
+                        Height="8.5"
+                        Icon="Times"/>
+                </StackPanel>
+
+                <Separator
+                    VerticalAlignment="Top"
+                    Width="212"
+                    Margin="0,29,0,0"
+                    Background="{StaticResource DarkGrayColor}"/>
+
                 <TextBlock
+                    Text="Still there?"
+                    Foreground="White"
+                    Margin="16,43.9,0,0"
+                    FontWeight="Bold"
                     FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                    FontSize="10"
-                    Foreground="White"
-                    Margin="5,0"
-                    Text="Cancel"/>
-                <fa:ImageAwesome
-                    Foreground="White"
-                    Height="8.5"
-                    Icon="Times"/>
-            </StackPanel>
+                    FontSize="19"/>
 
-            <Separator
-                VerticalAlignment="Top"
-                Width="212"
-                Margin="0,29,0,0"
-                Background="{StaticResource DarkGrayColor}"/>
-
-            <TextBlock
-                Text="Still there?"
-                Foreground="White"
-                Margin="16,43.9,0,0"
-                FontWeight="Bold"
-                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                FontSize="19"/>
-
-            <TextBlock
-                Text="Tap &quot;Still working&quot; before the countdown runs out or this workspace will be closed"
-                Foreground="White"
-                Margin="16,69.4,0,0"
-                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                Width="94"
-                Height="86"
-                VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                TextWrapping="Wrap"
-                FontSize="9"/>
-
-            <!--<Ellipse
-                Width="82"
-                Height="82"
-                Margin="134,72,0,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Top"
-                Stroke="#E5FF4D"
-                StrokeThickness="4"/>-->
-
-            <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
-                <Path Width="{Binding Width}" Height="{Binding Height}" Margin="{Binding Margin}" Stroke="#E5FF4D" StrokeThickness="8">
-                    <Path.Data>
-                        <PathGeometry>
-                            <PathGeometry.Figures>
-                                <PathFigureCollection>
-                                    <PathFigure StartPoint="{Binding StartPoint}">
-                                        <PathFigure.Segments>
-                                            <PathSegmentCollection>
-                                                <ArcSegment
-                                                    Point="{Binding ArcPoint}"
-                                                    Size="{Binding ArcSize}"
-                                                    IsLargeArc="{Binding IsLargeArc}"
-                                                    SweepDirection="CounterClockwise" />
-                                            </PathSegmentCollection>
-                                        </PathFigure.Segments>
-                                    </PathFigure>
-                                </PathFigureCollection>
-                            </PathGeometry.Figures>
-                        </PathGeometry>
-                    </Path.Data>
-                </Path>
-            </Grid>
-
-            <TextBlock Margin="160,74,0,0" FontSize="26" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Poppins" Foreground="White" FontWeight="Bold">
-                <Run>:</Run>
-                <Run Text="{Binding CurrentSeconds}"/>
-            </TextBlock>
-
-            <Button
-                Style="{StaticResource OutlineBtn}"
-                FontWeight="Bold"
-                Height="20"
-                HorizontalAlignment="Left"
-                Margin="15,0,0,14"
-                VerticalAlignment="Bottom"
-                Width="104">
                 <TextBlock
-                    Style="{StaticResource CommonType}"
-                    FontSize="10"
-                    HorizontalAlignment="Center"
-                    Text="Close now"
-                    VerticalAlignment="Center"/>
-            </Button>
+                    Text="Tap &quot;Still working&quot; before the countdown runs out or this workspace will be closed"
+                    Foreground="White"
+                    Margin="16,69.4,0,0"
+                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                    Width="94"
+                    Height="86"
+                    VerticalAlignment="Top"
+                    HorizontalAlignment="Left"
+                    TextWrapping="Wrap"
+                    FontSize="9"/>
 
-            <Button
-                Style="{StaticResource SuccessBtn}"
-                FontWeight="Bold"
-                Foreground="Black"
-                Height="20"
-                HorizontalAlignment="Right"
-                Margin="0,0,15.3,14.59"
-                VerticalAlignment="Bottom"
-                Width="104">
-                <Button.Effect>
-                    <DropShadowEffect BlurRadius="5" ShadowDepth="2"/>
-                </Button.Effect>
-                <TextBlock
-                    Style="{StaticResource CommonType}"
-                    FontSize="10"
+                <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
+                    <Path Width="{Binding Width}" Height="{Binding Height}" Margin="{Binding Margin}" Stroke="#E5FF4D" StrokeThickness="8">
+                        <Path.Data>
+                            <PathGeometry>
+                                <PathGeometry.Figures>
+                                    <PathFigureCollection>
+                                        <PathFigure StartPoint="{Binding StartPoint}">
+                                            <PathFigure.Segments>
+                                                <PathSegmentCollection>
+                                                    <ArcSegment
+                                                        Point="{Binding ArcPoint}"
+                                                        Size="{Binding ArcSize}"
+                                                        IsLargeArc="{Binding IsLargeArc}"
+                                                        SweepDirection="CounterClockwise" />
+                                                </PathSegmentCollection>
+                                            </PathFigure.Segments>
+                                        </PathFigure>
+                                    </PathFigureCollection>
+                                </PathGeometry.Figures>
+                            </PathGeometry>
+                        </Path.Data>
+                    </Path>
+                </Grid>
+
+                <TextBlock Margin="160,74,0,0" FontSize="26" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Poppins" Foreground="White" FontWeight="Bold">
+                    <Run>:</Run>
+                    <Run Text="{Binding CurrentSeconds, Mode=OneWay}"/>
+                </TextBlock>
+
+                <Button
+                    Style="{StaticResource OutlineBtn}"
+                    FontWeight="Bold"
+                    Height="20"
+                    HorizontalAlignment="Left"
+                    Margin="15,0,0,14"
+                    VerticalAlignment="Bottom"
+                    Width="104">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="TouchUp">
+                            <i:InvokeCommandAction Command="{Binding CloseClassifier}"/>
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
+                    <TextBlock
+                        Style="{StaticResource CommonType}"
+                        FontSize="10"
+                        HorizontalAlignment="Center"
+                        Text="Close now"
+                        VerticalAlignment="Center"/>
+                </Button>
+
+                <Button
+                    Style="{StaticResource SuccessBtn}"
+                    FontWeight="Bold"
                     Foreground="Black"
-                    HorizontalAlignment="Center"
-                    Text="Still working"
-                    VerticalAlignment="Center"/>
-            </Button>
-        </Grid>
+                    Height="20"
+                    HorizontalAlignment="Right"
+                    Margin="0,0,15.3,14.59"
+                    VerticalAlignment="Bottom"
+                    Width="104">
+                    <Button.Effect>
+                        <DropShadowEffect BlurRadius="5" ShadowDepth="2"/>
+                    </Button.Effect>
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="TouchUp">
+                            <i:InvokeCommandAction Command="{Binding CloseModal}"/>
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
+                    <TextBlock
+                        Style="{StaticResource CommonType}"
+                        FontSize="10"
+                        Foreground="Black"
+                        HorizontalAlignment="Center"
+                        Text="Still working"
+                        VerticalAlignment="Center"/>
+                </Button>
+            </Grid>
+        </Border>
     </Border>
 </UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -64,18 +64,18 @@
                     FontSize="9"/>
 
                 <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
-                    <Path Width="{Binding Width}" Height="{Binding Height}" Margin="{Binding Margin}" Stroke="#E5FF4D" StrokeThickness="8">
+                    <Path Width="90" Height="90" Stroke="#E5FF4D" StrokeThickness="8">
                         <Path.Data>
                             <PathGeometry>
                                 <PathGeometry.Figures>
                                     <PathFigureCollection>
-                                        <PathFigure StartPoint="{Binding StartPoint}">
+                                        <PathFigure StartPoint="{Binding Circle.StartPoint}">
                                             <PathFigure.Segments>
                                                 <PathSegmentCollection>
                                                     <ArcSegment
-                                                        Point="{Binding ArcPoint}"
-                                                        Size="{Binding ArcSize}"
-                                                        IsLargeArc="{Binding IsLargeArc}"
+                                                        Point="{Binding Circle.ArcPoint}"
+                                                        Size="{Binding Circle.ArcSize}"
+                                                        IsLargeArc="{Binding Circle.IsLargeArc}"
                                                         SweepDirection="CounterClockwise" />
                                                 </PathSegmentCollection>
                                             </PathFigure.Segments>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -25,11 +25,11 @@
             <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
-                <i:Interaction.Triggers>
+                <!--<i:Interaction.Triggers>
                     <i:EventTrigger EventName="TouchUp">
                         <i:InvokeCommandAction Command="{Binding ShowCloseConfirmation}"/>
                     </i:EventTrigger>
-                </i:Interaction.Triggers>
+                </i:Interaction.Triggers>-->
                 <TextBlock
                     FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
                     FontSize="10"
@@ -68,43 +68,43 @@
                 TextWrapping="Wrap"
                 FontSize="9"/>
 
-            <Ellipse
+            <!--<Ellipse
                 Width="82"
                 Height="82"
                 Margin="134,72,0,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
                 Stroke="#E5FF4D"
-                StrokeThickness="4"/>
+                StrokeThickness="4"/>-->
 
-            <!--<Path Stroke="Black" StrokeThickness="8" HorizontalAlignment="Right" Height="95" Width="95">
-                <Path.Data>
-                    <PathGeometry>
-                        <PathFigure StartPoint="46,5">
-                            <ArcSegment Size="41,41" IsLargeArc="True" SweepDirection="Counterclockwise" Point="48,5"/>
-                        </PathFigure>
-                    </PathGeometry>
-                </Path.Data>
-            </Path>-->
+            <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
+                <Path Width="{Binding Width}" Height="{Binding Height}" Margin="{Binding Margin}" Stroke="#E5FF4D" StrokeThickness="8">
+                    <Path.Data>
+                        <PathGeometry>
+                            <PathGeometry.Figures>
+                                <PathFigureCollection>
+                                    <PathFigure StartPoint="{Binding StartPoint}">
+                                        <PathFigure.Segments>
+                                            <PathSegmentCollection>
+                                                <ArcSegment
+                                                    Point="{Binding ArcPoint}"
+                                                    Size="{Binding ArcSize}"
+                                                    IsLargeArc="{Binding IsLargeArc}"
+                                                    SweepDirection="CounterClockwise" />
+                                            </PathSegmentCollection>
+                                        </PathFigure.Segments>
+                                    </PathFigure>
+                                </PathFigureCollection>
+                            </PathGeometry.Figures>
+                        </PathGeometry>
+                    </Path.Data>
+                </Path>
+            </Grid>
 
-            <Path x:Name="pathRoot" Stroke="Blue"
-                StrokeThickness="8">
-                <Path.Data>
-                    <PathGeometry>
-                        <PathGeometry.Figures>
-                            <PathFigureCollection>
-                                <PathFigure x:Name="pathFigure">
-                                    <PathFigure.Segments>
-                                        <PathSegmentCollection>
-                                            <ArcSegment x:Name="arcSegment" SweepDirection="CounterClockwise" />
-                                        </PathSegmentCollection>
-                                    </PathFigure.Segments>
-                                </PathFigure>
-                            </PathFigureCollection>
-                        </PathGeometry.Figures>
-                    </PathGeometry>
-                </Path.Data>
-            </Path>
+            <TextBlock Margin="160,74,0,0" FontSize="26" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Poppins" Foreground="White" FontWeight="Bold">
+                <Run>:</Run>
+                <Run Text="{Binding CurrentSeconds}"/>
+            </TextBlock>
 
             <Button
                 Style="{StaticResource OutlineBtn}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -1,0 +1,147 @@
+﻿<UserControl x:Class="GalaxyZooTouchTable.Views.StillThereModal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:GalaxyZooTouchTable.Views"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             mc:Ignorable="d" 
+             Height="291"
+             Width="312"
+             Background="#343438"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <Style x:Key="CommonType" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontFamily" Value="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+    </UserControl.Resources>
+    
+    <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
+        <Grid>
+            <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
+
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
+                <i:Interaction.Triggers>
+                    <i:EventTrigger EventName="TouchUp">
+                        <i:InvokeCommandAction Command="{Binding ShowCloseConfirmation}"/>
+                    </i:EventTrigger>
+                </i:Interaction.Triggers>
+                <TextBlock
+                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                    FontSize="10"
+                    Foreground="White"
+                    Margin="5,0"
+                    Text="Cancel"/>
+                <fa:ImageAwesome
+                    Foreground="White"
+                    Height="8.5"
+                    Icon="Times"/>
+            </StackPanel>
+
+            <Separator
+                VerticalAlignment="Top"
+                Width="212"
+                Margin="0,29,0,0"
+                Background="{StaticResource DarkGrayColor}"/>
+
+            <TextBlock
+                Text="Still there?"
+                Foreground="White"
+                Margin="16,43.9,0,0"
+                FontWeight="Bold"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                FontSize="19"/>
+
+            <TextBlock
+                Text="Tap &quot;Still working&quot; before the countdown runs out or this workspace will be closed"
+                Foreground="White"
+                Margin="16,69.4,0,0"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                Width="94"
+                Height="86"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                TextWrapping="Wrap"
+                FontSize="9"/>
+
+            <Ellipse
+                Width="82"
+                Height="82"
+                Margin="134,72,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Stroke="#E5FF4D"
+                StrokeThickness="4"/>
+
+            <!--<Path Stroke="Black" StrokeThickness="8" HorizontalAlignment="Right" Height="95" Width="95">
+                <Path.Data>
+                    <PathGeometry>
+                        <PathFigure StartPoint="46,5">
+                            <ArcSegment Size="41,41" IsLargeArc="True" SweepDirection="Counterclockwise" Point="48,5"/>
+                        </PathFigure>
+                    </PathGeometry>
+                </Path.Data>
+            </Path>-->
+
+            <Path x:Name="pathRoot" Stroke="Blue"
+                StrokeThickness="8">
+                <Path.Data>
+                    <PathGeometry>
+                        <PathGeometry.Figures>
+                            <PathFigureCollection>
+                                <PathFigure x:Name="pathFigure">
+                                    <PathFigure.Segments>
+                                        <PathSegmentCollection>
+                                            <ArcSegment x:Name="arcSegment" SweepDirection="CounterClockwise" />
+                                        </PathSegmentCollection>
+                                    </PathFigure.Segments>
+                                </PathFigure>
+                            </PathFigureCollection>
+                        </PathGeometry.Figures>
+                    </PathGeometry>
+                </Path.Data>
+            </Path>
+
+            <Button
+                Style="{StaticResource OutlineBtn}"
+                FontWeight="Bold"
+                Height="20"
+                HorizontalAlignment="Left"
+                Margin="15,0,0,14"
+                VerticalAlignment="Bottom"
+                Width="104">
+                <TextBlock
+                    Style="{StaticResource CommonType}"
+                    FontSize="10"
+                    HorizontalAlignment="Center"
+                    Text="Close now"
+                    VerticalAlignment="Center"/>
+            </Button>
+
+            <Button
+                Style="{StaticResource SuccessBtn}"
+                FontWeight="Bold"
+                Foreground="Black"
+                Height="20"
+                HorizontalAlignment="Right"
+                Margin="0,0,15.3,14.59"
+                VerticalAlignment="Bottom"
+                Width="104">
+                <Button.Effect>
+                    <DropShadowEffect BlurRadius="5" ShadowDepth="2"/>
+                </Button.Effect>
+                <TextBlock
+                    Style="{StaticResource CommonType}"
+                    FontSize="10"
+                    Foreground="Black"
+                    HorizontalAlignment="Center"
+                    Text="Still working"
+                    VerticalAlignment="Center"/>
+            </Button>
+        </Grid>
+    </Border>
+</UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Threading;
+﻿using System.Windows.Controls;
 
 namespace GalaxyZooTouchTable.Views
 {
@@ -10,70 +7,9 @@ namespace GalaxyZooTouchTable.Views
     /// </summary>
     public partial class StillThereModal : UserControl
     {
-        public DispatcherTimer ThirtySecondTimer { get; set; } = new DispatcherTimer();
-        public int Radius { get; set; } = 41;
-        public int Percentage { get; set; } = 100;
-        public int StrokeThickness { get; set; } = 4;
-        public decimal CurrentSeconds { get; set; } = 30;
-
         public StillThereModal()
         {
             InitializeComponent();
-            //StartTimer();
-            //RenderArc();
         }
-
-        //private void StartTimer()
-        //{
-        //    ThirtySecondTimer.Tick += new System.EventHandler(OneSecondElapsed);
-        //    ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 1);
-        //    ThirtySecondTimer.Start();
-        //}
-
-        //private void OneSecondElapsed(object sender, System.EventArgs e)
-        //{
-        //    decimal StartingSeconds = 30;
-        //    decimal test = CurrentSeconds / StartingSeconds;
-        //    decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
-        //    Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
-        //    RenderArc();
-        //    CurrentSeconds--;
-        //}
-
-        //private Point ComputeCartesianCoordinate(double angle, double radius)
-        //{
-        //    double angleRad = (Math.PI / 180.0) * (angle - 90);
-
-        //    double x = radius * Math.Cos(angleRad);
-        //    double y = radius * Math.Sin(angleRad);
-
-        //    return new Point(x, y);
-        //}
-
-        //public void RenderArc()
-        //{
-        //    int Angle = -(Percentage * 360) / 100;
-        //    Point startPoint = new Point(Radius, 0);
-        //    Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
-        //    endPoint.X += Radius;
-        //    endPoint.Y += Radius;
-
-        //    pathRoot.Width = Radius * 2 + StrokeThickness + 10;
-        //    pathRoot.Height = Radius * 2 + StrokeThickness + 10;
-        //    pathRoot.Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
-
-        //    bool largeArc = -Angle > 180.0;
-
-        //    Size outerArcSize = new Size(Radius, Radius);
-
-        //    pathFigure.StartPoint = startPoint;
-
-        //    if (startPoint.X == Math.Round(endPoint.X) && startPoint.Y == Math.Round(endPoint.Y))
-        //        endPoint.X += 0.01;
-
-        //    arcSegment.Point = endPoint;
-        //    arcSegment.Size = outerArcSize;
-        //    arcSegment.IsLargeArc = largeArc;
-        //}
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace GalaxyZooTouchTable.Views
+{
+    /// <summary>
+    /// Interaction logic for StillThereModal.xaml
+    /// </summary>
+    public partial class StillThereModal : UserControl
+    {
+        public DispatcherTimer ThirtySecondTimer { get; set; } = new DispatcherTimer();
+        public int Radius { get; set; } = 41;
+        public int Percentage { get; set; } = 100;
+        public int StrokeThickness { get; set; } = 4;
+        public decimal CurrentSeconds { get; set; } = 30;
+
+        public StillThereModal()
+        {
+            InitializeComponent();
+            StartTimer();
+            RenderArc();
+        }
+
+        private void StartTimer()
+        {
+            ThirtySecondTimer.Tick += new System.EventHandler(OneSecondElapsed);
+            ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 1);
+            ThirtySecondTimer.Start();
+        }
+
+        private void OneSecondElapsed(object sender, System.EventArgs e)
+        {
+            decimal StartingSeconds = 30;
+            decimal test = CurrentSeconds / StartingSeconds;
+            decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
+            Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
+            RenderArc();
+            CurrentSeconds--;
+        }
+
+        private Point ComputeCartesianCoordinate(double angle, double radius)
+        {
+            double angleRad = (Math.PI / 180.0) * (angle - 90);
+
+            double x = radius * Math.Cos(angleRad);
+            double y = radius * Math.Sin(angleRad);
+
+            return new Point(x, y);
+        }
+
+        public void RenderArc()
+        {
+            int Angle = -(Percentage * 360) / 100;
+            Point startPoint = new Point(Radius, 0);
+            Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
+            endPoint.X += Radius;
+            endPoint.Y += Radius;
+
+            pathRoot.Width = Radius * 2 + StrokeThickness + 10;
+            pathRoot.Height = Radius * 2 + StrokeThickness + 10;
+            pathRoot.Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
+
+            bool largeArc = -Angle > 180.0;
+
+            Size outerArcSize = new Size(Radius, Radius);
+
+            pathFigure.StartPoint = startPoint;
+
+            if (startPoint.X == Math.Round(endPoint.X) && startPoint.Y == Math.Round(endPoint.Y))
+                endPoint.X += 0.01;
+
+            arcSegment.Point = endPoint;
+            arcSegment.Size = outerArcSize;
+            arcSegment.IsLargeArc = largeArc;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml.cs
@@ -19,61 +19,61 @@ namespace GalaxyZooTouchTable.Views
         public StillThereModal()
         {
             InitializeComponent();
-            StartTimer();
-            RenderArc();
+            //StartTimer();
+            //RenderArc();
         }
 
-        private void StartTimer()
-        {
-            ThirtySecondTimer.Tick += new System.EventHandler(OneSecondElapsed);
-            ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 1);
-            ThirtySecondTimer.Start();
-        }
+        //private void StartTimer()
+        //{
+        //    ThirtySecondTimer.Tick += new System.EventHandler(OneSecondElapsed);
+        //    ThirtySecondTimer.Interval = new System.TimeSpan(0, 0, 1);
+        //    ThirtySecondTimer.Start();
+        //}
 
-        private void OneSecondElapsed(object sender, System.EventArgs e)
-        {
-            decimal StartingSeconds = 30;
-            decimal test = CurrentSeconds / StartingSeconds;
-            decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
-            Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
-            RenderArc();
-            CurrentSeconds--;
-        }
+        //private void OneSecondElapsed(object sender, System.EventArgs e)
+        //{
+        //    decimal StartingSeconds = 30;
+        //    decimal test = CurrentSeconds / StartingSeconds;
+        //    decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
+        //    Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
+        //    RenderArc();
+        //    CurrentSeconds--;
+        //}
 
-        private Point ComputeCartesianCoordinate(double angle, double radius)
-        {
-            double angleRad = (Math.PI / 180.0) * (angle - 90);
+        //private Point ComputeCartesianCoordinate(double angle, double radius)
+        //{
+        //    double angleRad = (Math.PI / 180.0) * (angle - 90);
 
-            double x = radius * Math.Cos(angleRad);
-            double y = radius * Math.Sin(angleRad);
+        //    double x = radius * Math.Cos(angleRad);
+        //    double y = radius * Math.Sin(angleRad);
 
-            return new Point(x, y);
-        }
+        //    return new Point(x, y);
+        //}
 
-        public void RenderArc()
-        {
-            int Angle = -(Percentage * 360) / 100;
-            Point startPoint = new Point(Radius, 0);
-            Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
-            endPoint.X += Radius;
-            endPoint.Y += Radius;
+        //public void RenderArc()
+        //{
+        //    int Angle = -(Percentage * 360) / 100;
+        //    Point startPoint = new Point(Radius, 0);
+        //    Point endPoint = ComputeCartesianCoordinate(Angle, Radius);
+        //    endPoint.X += Radius;
+        //    endPoint.Y += Radius;
 
-            pathRoot.Width = Radius * 2 + StrokeThickness + 10;
-            pathRoot.Height = Radius * 2 + StrokeThickness + 10;
-            pathRoot.Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
+        //    pathRoot.Width = Radius * 2 + StrokeThickness + 10;
+        //    pathRoot.Height = Radius * 2 + StrokeThickness + 10;
+        //    pathRoot.Margin = new Thickness(StrokeThickness, StrokeThickness, 0, 0);
 
-            bool largeArc = -Angle > 180.0;
+        //    bool largeArc = -Angle > 180.0;
 
-            Size outerArcSize = new Size(Radius, Radius);
+        //    Size outerArcSize = new Size(Radius, Radius);
 
-            pathFigure.StartPoint = startPoint;
+        //    pathFigure.StartPoint = startPoint;
 
-            if (startPoint.X == Math.Round(endPoint.X) && startPoint.Y == Math.Round(endPoint.Y))
-                endPoint.X += 0.01;
+        //    if (startPoint.X == Math.Round(endPoint.X) && startPoint.Y == Math.Round(endPoint.Y))
+        //        endPoint.X += 0.01;
 
-            arcSegment.Point = endPoint;
-            arcSegment.Size = outerArcSize;
-            arcSegment.IsLargeArc = largeArc;
-        }
+        //    arcSegment.Point = endPoint;
+        //    arcSegment.Size = outerArcSize;
+        //    arcSegment.IsLargeArc = largeArc;
+        //}
     }
 }


### PR DESCRIPTION
Closes #28 

This PR adds functionality to close the classifier after five minutes of inactivity. Note, there is a gradient on the circle timer according to [the design](https://projects.invisionapp.com/d/main#/console/15093515/336156649/preview), but WPF doesn't have an angular/circular gradient built-in (only a linear and radial gradient). Because of this, some more work (potential DirectX shading) will have to be done in a separate PR.

I also added a `ViewModelBase` class here to make view model code read a bit better. Other viewmodels can thus be refactored a bit.