### PR TITLE
Fix Minor Bugs

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/DisableOpacityMaskOnEndScroll.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/DisableOpacityMaskOnEndScroll.cs
@@ -21,8 +21,8 @@ namespace GalaxyZooTouchTable.Behaviors
         private void SetOpacityMask()
         {
             var gradientCollection = new GradientStopCollection();
-            var gradientStop1 = new GradientStop(Color.FromRgb(0, 0, 0), 0);
-            var gradientStop2 = new GradientStop(Color.FromArgb(0, 0, 0, 0), 1);
+            var gradientStop1 = new GradientStop(Colors.Black, 0);
+            var gradientStop2 = new GradientStop(Colors.Transparent, 1);
             gradientCollection.Add(gradientStop1);
             gradientCollection.Add(gradientStop2);
             
@@ -44,7 +44,7 @@ namespace GalaxyZooTouchTable.Behaviors
             AssociatedObject.OpacityMask = InitialOpacityMask;
         }
 
-        public static readonly DependencyProperty IsHorizontalProperty =
+        private static readonly DependencyProperty IsHorizontalProperty =
             DependencyProperty.Register("IsHorizontal", typeof(Boolean), typeof(DisableOpacityMaskOnEndScroll));
 
         public bool IsHorizontal
@@ -53,7 +53,7 @@ namespace GalaxyZooTouchTable.Behaviors
             set { SetValue(IsHorizontalProperty, value); }
         }
 
-        public static readonly DependencyProperty StartPercentProperty =
+        private static readonly DependencyProperty StartPercentProperty =
             DependencyProperty.Register("StartPercent", typeof(double), typeof(DisableOpacityMaskOnEndScroll));
 
         public double StartPercent

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/DisableOpacityMaskOnEndScroll.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/DisableOpacityMaskOnEndScroll.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interactivity;
+using System.Windows.Media;
+
+namespace GalaxyZooTouchTable.Behaviors
+{
+    public class DisableOpacityMaskOnEndScroll : Behavior<ScrollViewer>
+    {
+        private LinearGradientBrush InitialOpacityMask { get; set; }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            AssociatedObject.ScrollChanged += AssociatedObject_ScrollChanged;
+            SetOpacityMask();
+        }
+
+        private void SetOpacityMask()
+        {
+            var gradientCollection = new GradientStopCollection();
+            var gradientStop1 = new GradientStop(Color.FromRgb(0, 0, 0), 0);
+            var gradientStop2 = new GradientStop(Color.FromArgb(0, 0, 0, 0), 1);
+            gradientCollection.Add(gradientStop1);
+            gradientCollection.Add(gradientStop2);
+            
+
+            Point StartPoint = new Point();
+            Point EndPoint = new Point();
+            if (IsHorizontal)
+            {
+                StartPoint.X = StartPercent;
+                EndPoint.X = 1;
+            }
+            else
+            {
+                StartPoint.Y = StartPercent;
+                EndPoint.Y = 1;
+            }
+
+            InitialOpacityMask = new LinearGradientBrush(gradientCollection, StartPoint, EndPoint);
+            AssociatedObject.OpacityMask = InitialOpacityMask;
+        }
+
+        public static readonly DependencyProperty IsHorizontalProperty =
+            DependencyProperty.Register("IsHorizontal", typeof(Boolean), typeof(DisableOpacityMaskOnEndScroll));
+
+        public bool IsHorizontal
+        {
+            get { return (bool)GetValue(IsHorizontalProperty); }
+            set { SetValue(IsHorizontalProperty, value); }
+        }
+
+        public static readonly DependencyProperty StartPercentProperty =
+            DependencyProperty.Register("StartPercent", typeof(double), typeof(DisableOpacityMaskOnEndScroll));
+
+        public double StartPercent
+        {
+            get { return (double)GetValue(StartPercentProperty); }
+            set { SetValue(StartPercentProperty, value); }
+        }
+
+        private void AssociatedObject_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (AssociatedObject.ScrollableHeight == AssociatedObject.VerticalOffset && !IsHorizontal)
+            {
+                AssociatedObject.OpacityMask = null;
+            }
+            else if (AssociatedObject.ScrollableWidth == AssociatedObject.HorizontalOffset && IsHorizontal)
+            {
+                AssociatedObject.OpacityMask = null;
+            }
+            else
+            {
+                AssociatedObject.OpacityMask = InitialOpacityMask;
+            }
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Converters/ProgressWidthConverter.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Converters/ProgressWidthConverter.cs
@@ -13,11 +13,13 @@ namespace GalaxyZooTouchTable
         {
             if (values.Length >= 3)
             {
+                const double MINIMUM_PERCENT = 0.06;
                 double Width = System.Convert.ToDouble(values[0]);
                 double Value = System.Convert.ToDouble(values[1]);
                 double Maximum = System.Convert.ToDouble(values[2]);
 
                 double Percent = Value / Maximum;
+                Percent = Percent > 0 ? Math.Max(Percent, MINIMUM_PERCENT) : Percent;
                 return Percent * Width;
             }
             return null;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -184,6 +184,7 @@
     </Compile>
     <Compile Include="Behaviors\UIElementDragBehavior.cs" />
     <Compile Include="Behaviors\UIElementDropBehavior.cs" />
+    <Compile Include="Behaviors\DisableOpacityMaskOnEndScroll.cs" />
     <Compile Include="Converters\EqualityConverter.cs" />
     <Compile Include="Converters\FontSizeConverter.cs" />
     <Compile Include="Converters\HidePanelConverter.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -25,7 +25,6 @@ namespace GalaxyZooTouchTable.ViewModels
         private Workflow Workflow { get; set; }
 
         public ExamplesPanelViewModel ExamplesViewModel { get; private set; } = new ExamplesPanelViewModel();
-        public LevelerViewModel LevelerViewModel { get; private set; }
         public NotificationsViewModel Notifications { get; private set; }
         public TableUser User { get; set; }
 
@@ -41,6 +40,13 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             get => _currentAnswers;
             set => SetProperty(ref _currentAnswers, value);
+        }
+
+        private LevelerViewModel _levelerViewModel;
+        public LevelerViewModel LevelerViewModel
+        {
+            get => _levelerViewModel;
+            set => SetProperty(ref _levelerViewModel, value);
         }
 
         private StillThereViewModel _stillThere;
@@ -210,6 +216,7 @@ namespace GalaxyZooTouchTable.ViewModels
             StartTimer();
             ClassifierOpen = true;
             User.Active = true;
+            LevelerViewModel = new LevelerViewModel(User);
         }
 
         private void OnCloseClassifier(object sender)
@@ -217,7 +224,6 @@ namespace GalaxyZooTouchTable.ViewModels
             SubjectView = SubjectViewEnum.DragSubject;
             Notifications.ClearNotifications(true);
             StillThereTimer = null;
-            LevelerViewModel.IsOpen = false;
             ExamplesViewModel.IsOpen = true;
             ExamplesViewModel.SelectedExample = null;
             PrepareForNewClassification();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -309,7 +309,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (StillThereTimer != null)
             {
-                StillThereTimer.Interval = new System.TimeSpan(0, 4, 30);
+                StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
                 StillThereTimer.Start();
             }
             if (StillThere.Visible) { StillThere.Visible = false; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
@@ -8,11 +8,11 @@ namespace GalaxyZooTouchTable.ViewModels
     {
         public TableUser User { get; set; }
         public ICommand ToggleLeveler { get; private set; }
-        const string MAX_LEVEL = "Five";
-        const int DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE = 5;
-        const int DEFAULT_CLASSIFICATIONS_COUNT = 5;
-        const string DEFAULT_CLASSIFICATION_LEVEL = "One";
-        const bool DEFAULT_CLASSIFICATION_OPEN = false;
+        private const string MAX_LEVEL = "Five";
+        private const int DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE = 5;
+        private const int DEFAULT_CLASSIFICATIONS_COUNT = 5;
+        private const string DEFAULT_CLASSIFICATION_LEVEL = "One";
+        private const bool DEFAULT_CLASSIFICATION_OPEN = false;
 
         private int _classificationsUntilUpgrade = DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE;
         public int ClassificationsUntilUpgrade

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
@@ -9,8 +9,12 @@ namespace GalaxyZooTouchTable.ViewModels
         public TableUser User { get; set; }
         public ICommand ToggleLeveler { get; private set; }
         const string MAX_LEVEL = "Five";
+        const int DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE = 5;
+        const int DEFAULT_CLASSIFICATIONS_COUNT = 5;
+        const string DEFAULT_CLASSIFICATION_LEVEL = "One";
+        const bool DEFAULT_CLASSIFICATION_OPEN = false;
 
-        private int _classificationsUntilUpgrade = 5;
+        private int _classificationsUntilUpgrade = DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE;
         public int ClassificationsUntilUpgrade
         {
             get => _classificationsUntilUpgrade;
@@ -25,7 +29,7 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private int _classificationsThisSession = 0;
+        private int _classificationsThisSession = DEFAULT_CLASSIFICATIONS_COUNT;
         public int ClassificationsThisSession
         {
             get => _classificationsThisSession;
@@ -36,14 +40,14 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private string _classificationLevel = "One";
+        private string _classificationLevel = DEFAULT_CLASSIFICATION_LEVEL;
         public string ClassificationLevel
         {
             get => _classificationLevel;
             set => SetProperty(ref _classificationLevel, value);
         }
 
-        private bool _isOpen = false;
+        private bool _isOpen = DEFAULT_CLASSIFICATION_OPEN;
         public bool IsOpen
         {
             get => _isOpen;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:Lib="clr-namespace:GalaxyZooTouchTable.Lib"
+             xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF"
              xmlns:System="clr-namespace:System;assembly=mscorlib"
@@ -253,35 +254,6 @@
             <Setter Property="HorizontalScrollBarVisibility" Value="Hidden"/>
             <Setter Property="PanningMode" Value="HorizontalOnly"/>
             <Setter Property="Margin" Value="0,15,0,0"/>
-            <Setter Property="OpacityMask">
-                <Setter.Value>
-                    <LinearGradientBrush StartPoint="0.99,1" EndPoint="1,1" Opacity="1">
-                        <LinearGradientBrush.GradientStops>
-                           <GradientStop Offset="0" Color="Black"/>
-                           <GradientStop Offset="1" Color="Transparent"/>
-                        </LinearGradientBrush.GradientStops>
-                    </LinearGradientBrush>
-                </Setter.Value>
-            </Setter>
-
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
-                    <DataTrigger.EnterActions>
-                        <BeginStoryboard>
-                            <Storyboard BeginTime="0:0:0.2">
-                                <PointAnimation Storyboard.TargetProperty="(ScrollViewer.OpacityMask).(StartPoint)" To="0.85,1" Duration="0:0:0.1"/>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </DataTrigger.EnterActions>
-                    <DataTrigger.ExitActions>
-                        <BeginStoryboard>
-                            <Storyboard>
-                                <PointAnimation Storyboard.TargetProperty="(ScrollViewer.OpacityMask).(StartPoint)" Duration="0:0:0.1"/>
-                            </Storyboard>
-                        </BeginStoryboard>
-                    </DataTrigger.ExitActions>
-                </DataTrigger>
-            </Style.Triggers>
         </Style>
 
         <Style x:Key="SelectedItemText" TargetType="{x:Type ScrollViewer}">
@@ -446,6 +418,9 @@
                     </StackPanel>
 
                     <ScrollViewer x:Name="SmoothScroller" Style="{StaticResource ExampleScrollViewer}">
+                        <i:Interaction.Behaviors>
+                            <Behaviors:DisableOpacityMaskOnEndScroll IsHorizontal="True" StartPercent="0.9"/>
+                        </i:Interaction.Behaviors>
                         <StackPanel Style="{StaticResource ScrollableStackPanel}">
                             <Border Style="{StaticResource ExampleImage}">
                                 <Border.Background>
@@ -495,6 +470,9 @@
                     </StackPanel>
 
                     <ScrollViewer x:Name="FeaturesScroller" Style="{StaticResource ExampleScrollViewer}">
+                        <i:Interaction.Behaviors>
+                            <Behaviors:DisableOpacityMaskOnEndScroll IsHorizontal="True" StartPercent="0.9"/>
+                        </i:Interaction.Behaviors>
                         <StackPanel Style="{StaticResource ScrollableStackPanel}">
                             <Border Style="{StaticResource ExampleImage}">
                                 <Border.Background>
@@ -544,6 +522,9 @@
                     </StackPanel>
 
                     <ScrollViewer x:Name="NotAGalaxyScroller" Style="{StaticResource ExampleScrollViewer}">
+                        <i:Interaction.Behaviors>
+                            <Behaviors:DisableOpacityMaskOnEndScroll IsHorizontal="True" StartPercent="0.9"/>
+                        </i:Interaction.Behaviors>
                         <StackPanel Style="{StaticResource ScrollableStackPanel}">
                             <Border Style="{StaticResource ExampleImage}">
                                 <Border.Background>
@@ -565,14 +546,9 @@
                 </Grid>
 
                 <ScrollViewer Canvas.Top="140" x:Name="ItemText" Style="{StaticResource SelectedItemText}">
-                        <ScrollViewer.OpacityMask>
-                            <LinearGradientBrush StartPoint="0,0.6" EndPoint="0,1">
-                                <LinearGradientBrush.GradientStops>
-                                    <GradientStop Offset="0" Color="Black"/>
-                                    <GradientStop Offset="1" Color="Transparent"/>
-                                </LinearGradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                        </ScrollViewer.OpacityMask>
+                    <i:Interaction.Behaviors>
+                        <Behaviors:DisableOpacityMaskOnEndScroll IsHorizontal="False" StartPercent="0.6"/>
+                    </i:Interaction.Behaviors>
                     <StackPanel Style="{StaticResource SelectedTextStackPanel}">
                         <StackPanel.RenderTransform>
                             <TranslateTransform X="{Binding Path=ActualWidth, ElementName=ItemText, Converter={StaticResource HidePanelConverter}, ConverterParameter='-1'}"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -26,16 +26,32 @@
         </Storyboard>
 
         <Storyboard x:Key="BeginRotateArrowStoryboard">
-            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(RotateTransform.Angle)" To="180" Duration="0:0:0.1"/>
+            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[0].(RotateTransform.Angle)" To="180" Duration="0:0:0.1"/>
         </Storyboard>
 
         <Storyboard x:Key="ReturnRotateArrowStoryboard">
-            <DoubleAnimation Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(RotateTransform.Angle)" Duration="0:0:0.1"/>
+            <DoubleAnimation Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[0].(RotateTransform.Angle)" Duration="0:0:0.1"/>
+        </Storyboard>
+
+        <Storyboard x:Key="MoveArrowLeftStoryboard">
+            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)" To="-35" Duration="0:0:0.1"/>
+        </Storyboard>        
+        
+        <Storyboard x:Key="MoveArrowRightStoryboard">
+            <DoubleAnimation Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)" Duration="0:0:0.1"/>
+        </Storyboard>
+
+        <Storyboard x:Key="MoveToggleTextRight">
+            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(TextBlock.RenderTransform).(TranslateTransform.X)" To="8" Duration="0:0:0.1"/>
+        </Storyboard>
+
+        <Storyboard x:Key="MoveToggleTextLeft">
+            <DoubleAnimation Storyboard.TargetProperty="(TextBlock.RenderTransform).(TranslateTransform.X)" Duration="0:0:0.1"/>
         </Storyboard>
 
         <Style x:Key="ExampleArrow" TargetType="{x:Type fa:ImageAwesome}">
             <Setter Property="Foreground" Value="White"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Icon" Value="CaretRight"/>
             <Setter Property="Margin" Value="4,1,0,0"/>
             <Setter Property="Height" Value="5"/>
@@ -45,9 +61,11 @@
                 <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
                     <DataTrigger.EnterActions>
                         <BeginStoryboard Storyboard="{StaticResource BeginRotateArrowStoryboard}"/>
+                        <BeginStoryboard Storyboard="{StaticResource MoveArrowLeftStoryboard}"/>
                     </DataTrigger.EnterActions>
                     <DataTrigger.ExitActions>
                         <BeginStoryboard Storyboard="{StaticResource ReturnRotateArrowStoryboard}"/>
+                        <BeginStoryboard Storyboard="{StaticResource MoveArrowRightStoryboard}"/>
                     </DataTrigger.ExitActions>
                 </DataTrigger>
             </Style.Triggers>
@@ -136,7 +154,6 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-
 
         <Style x:Key="NotAGalaxyExample" TargetType="{x:Type Grid}" BasedOn="{StaticResource GalaxyExamples}">
             <Style.Triggers>
@@ -279,17 +296,17 @@
             <Setter Property="Height" Value="Auto"/>
         </Style>
 
-        <Style x:Key="ExampleStackPanel" TargetType="{x:Type StackPanel}">
+        <Style x:Key="ExampleGrid" TargetType="{x:Type Grid}">
             <Setter Property="VerticalAlignment" Value="Top"/>
-            <Setter Property="Margin" Value="18,0"/>
-            <Setter Property="Orientation" Value="Horizontal"/>
+            <Setter Property="Margin" Value="18,0,14,0"/>
             <Setter Property="Height" Value="10"/>
             <Setter Property="Background" Value="{StaticResource MedGrayColor}"/>
         </Style>
 
         <Style x:Key="ExampleTextBlock" TargetType="{x:Type TextBlock}">
-            <Setter Property="FontSize" Value="9"/>
+            <Setter Property="FontSize" Value="7.5"/>
             <Setter Property="Foreground" Value="White"/>
+            <Setter Property="VerticalAlignment" Value="Bottom"/>
             <Setter Property="FontFamily" Value="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
         </Style>
 
@@ -356,6 +373,29 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
+
+        <Style x:Key="ToggleText" BasedOn="{StaticResource ExampleText}" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="6.75"/>
+            <Setter Property="VerticalAlignment" Value="Bottom"/>
+            <Setter Property="Typography.Capitals" Value="AllSmallCaps"/>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard Storyboard="{StaticResource MoveToggleTextRight}"/>
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <BeginStoryboard Storyboard="{StaticResource MoveToggleTextLeft}"/>
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="ToggleStackPanel" TargetType="{x:Type StackPanel}">
+            <Setter Property="Orientation" Value="Horizontal"/>
+            <Setter Property="VerticalAlignment" Value="Bottom"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+        </Style>
     </UserControl.Resources>
 
     <Viewbox>
@@ -382,7 +422,10 @@
                     <TextBlock Margin="0,12,0,0" Text="Tap each item to learn more." FontSize="7" Foreground="White" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla" FontStyle="Italic"/>
                     <fa:ImageAwesome Style="{StaticResource ToggleArrowStyle}">
                         <fa:ImageAwesome.RenderTransform>
-                            <RotateTransform/>
+                            <TransformGroup>
+                                <RotateTransform/>
+                                <TranslateTransform/>
+                            </TransformGroup>
                         </fa:ImageAwesome.RenderTransform>
                     </fa:ImageAwesome>
                 </Grid>
@@ -395,14 +438,14 @@
 
                 <Separator Canvas.Top="36.15" Style="{StaticResource GridSeparators}"/>
 
-                <Grid Canvas.Top="44.2" Style="{StaticResource SmoothExample}">
+                <Grid Canvas.Top="44" Style="{StaticResource SmoothExample}">
                     <i:Interaction.Triggers>
                         <Lib:HandlingEventTrigger EventName="TouchUp">
                             <i:InvokeCommandAction Command="{Binding SelectItem}" CommandParameter="{Binding Smooth}"/>
                         </Lib:HandlingEventTrigger>
                     </i:Interaction.Triggers>
 
-                    <StackPanel Style="{StaticResource ExampleStackPanel}" TouchUp="SmoothStackPanel_TouchUp">
+                    <Grid Style="{StaticResource ExampleGrid}" TouchUp="SmoothStackPanel_TouchUp">
                         <i:Interaction.Triggers>
                             <Lib:HandlingEventTrigger EventName="TouchUp">
                                 <i:InvokeCommandAction Command="{Binding UnselectItem}" CommandParameter="{Binding Smooth}"/>
@@ -410,12 +453,22 @@
                         </i:Interaction.Triggers>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Smooth"/>
-                        <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
-                            <fa:ImageAwesome.RenderTransform>
-                                <RotateTransform/>
-                            </fa:ImageAwesome.RenderTransform>
-                        </fa:ImageAwesome>
-                    </StackPanel>
+                        <StackPanel Style="{StaticResource ToggleStackPanel}">
+                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                                <TextBlock.RenderTransform>
+                                    <TranslateTransform/>
+                                </TextBlock.RenderTransform>
+                            </TextBlock>
+                            <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
+                                <fa:ImageAwesome.RenderTransform>
+                                    <TransformGroup>
+                                        <RotateTransform/>
+                                        <TranslateTransform/>
+                                    </TransformGroup>
+                                </fa:ImageAwesome.RenderTransform>
+                            </fa:ImageAwesome>
+                        </StackPanel>
+                    </Grid>
 
                     <ScrollViewer x:Name="SmoothScroller" Style="{StaticResource ExampleScrollViewer}">
                         <i:Interaction.Behaviors>
@@ -454,7 +507,7 @@
                         </Lib:HandlingEventTrigger>
                     </i:Interaction.Triggers>
 
-                    <StackPanel Style="{StaticResource ExampleStackPanel}" TouchUp="FeaturesStackPanel_TouchUp">
+                    <Grid Style="{StaticResource ExampleGrid}" TouchUp="FeaturesStackPanel_TouchUp">
                         <i:Interaction.Triggers>
                             <Lib:HandlingEventTrigger EventName="TouchUp">
                                 <i:InvokeCommandAction Command="{Binding UnselectItem}" CommandParameter="{Binding Features}"/>
@@ -462,12 +515,22 @@
                         </i:Interaction.Triggers>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Features"/>
-                        <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
-                            <fa:ImageAwesome.RenderTransform>
-                                <RotateTransform/>
-                            </fa:ImageAwesome.RenderTransform>
-                        </fa:ImageAwesome>
-                    </StackPanel>
+                        <StackPanel Style="{StaticResource ToggleStackPanel}">
+                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                                <TextBlock.RenderTransform>
+                                    <TranslateTransform/>
+                                </TextBlock.RenderTransform>
+                            </TextBlock>
+                            <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
+                                <fa:ImageAwesome.RenderTransform>
+                                    <TransformGroup>
+                                        <RotateTransform/>
+                                        <TranslateTransform/>
+                                    </TransformGroup>
+                                </fa:ImageAwesome.RenderTransform>
+                            </fa:ImageAwesome>
+                        </StackPanel>
+                    </Grid>
 
                     <ScrollViewer x:Name="FeaturesScroller" Style="{StaticResource ExampleScrollViewer}">
                         <i:Interaction.Behaviors>
@@ -506,7 +569,7 @@
                         </Lib:HandlingEventTrigger>
                     </i:Interaction.Triggers>
 
-                    <StackPanel Style="{StaticResource ExampleStackPanel}" TouchUp="NotAGalaxyStackPanel_TouchUp">
+                    <Grid Style="{StaticResource ExampleGrid}" TouchUp="NotAGalaxyStackPanel_TouchUp">
                         <i:Interaction.Triggers>
                             <Lib:HandlingEventTrigger EventName="TouchUp">
                                 <i:InvokeCommandAction Command="{Binding UnselectItem}" CommandParameter="{Binding NotAGalaxy}"/>
@@ -514,12 +577,22 @@
                         </i:Interaction.Triggers>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Not a Galaxy"/>
-                        <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
-                            <fa:ImageAwesome.RenderTransform>
-                                <RotateTransform/>
-                            </fa:ImageAwesome.RenderTransform>
-                        </fa:ImageAwesome>
-                    </StackPanel>
+                        <StackPanel Style="{StaticResource ToggleStackPanel}">
+                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                                <TextBlock.RenderTransform>
+                                    <TranslateTransform/>
+                                </TextBlock.RenderTransform>
+                            </TextBlock>
+                            <fa:ImageAwesome Style="{StaticResource ExampleArrow}">
+                                <fa:ImageAwesome.RenderTransform>
+                                    <TransformGroup>
+                                        <RotateTransform/>
+                                        <TranslateTransform/>
+                                    </TransformGroup>
+                                </fa:ImageAwesome.RenderTransform>
+                            </fa:ImageAwesome>
+                        </StackPanel>
+                    </Grid>
 
                     <ScrollViewer x:Name="NotAGalaxyScroller" Style="{StaticResource ExampleScrollViewer}">
                         <i:Interaction.Behaviors>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -253,6 +253,35 @@
             <Setter Property="HorizontalScrollBarVisibility" Value="Hidden"/>
             <Setter Property="PanningMode" Value="HorizontalOnly"/>
             <Setter Property="Margin" Value="0,15,0,0"/>
+            <Setter Property="OpacityMask">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0.99,1" EndPoint="1,1" Opacity="1">
+                        <LinearGradientBrush.GradientStops>
+                           <GradientStop Offset="0" Color="Black"/>
+                           <GradientStop Offset="1" Color="Transparent"/>
+                        </LinearGradientBrush.GradientStops>
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard>
+                            <Storyboard BeginTime="0:0:0.2">
+                                <PointAnimation Storyboard.TargetProperty="(ScrollViewer.OpacityMask).(StartPoint)" To="0.85,1" Duration="0:0:0.1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <PointAnimation Storyboard.TargetProperty="(ScrollViewer.OpacityMask).(StartPoint)" Duration="0:0:0.1"/>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+            </Style.Triggers>
         </Style>
 
         <Style x:Key="SelectedItemText" TargetType="{x:Type ScrollViewer}">
@@ -536,6 +565,14 @@
                 </Grid>
 
                 <ScrollViewer Canvas.Top="140" x:Name="ItemText" Style="{StaticResource SelectedItemText}">
+                        <ScrollViewer.OpacityMask>
+                            <LinearGradientBrush StartPoint="0,0.6" EndPoint="0,1">
+                                <LinearGradientBrush.GradientStops>
+                                    <GradientStop Offset="0" Color="Black"/>
+                                    <GradientStop Offset="1" Color="Transparent"/>
+                                </LinearGradientBrush.GradientStops>
+                            </LinearGradientBrush>
+                        </ScrollViewer.OpacityMask>
                     <StackPanel Style="{StaticResource SelectedTextStackPanel}">
                         <StackPanel.RenderTransform>
                             <TranslateTransform X="{Binding Path=ActualWidth, ElementName=ItemText, Converter={StaticResource HidePanelConverter}, ConverterParameter='-1'}"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -496,9 +496,9 @@
                     </ScrollViewer>
                 </Grid>
 
-                <Separator Canvas.Top="96.15" Style="{StaticResource HidingGridSeparators}"/>
+                <Separator Canvas.Top="95" Style="{StaticResource HidingGridSeparators}"/>
 
-                <Grid Canvas.Top="95" Style="{StaticResource FeaturesExample}">
+                <Grid Canvas.Top="96" Style="{StaticResource FeaturesExample}">
                     <Grid.RenderTransform>
                         <TranslateTransform/>
                     </Grid.RenderTransform>
@@ -558,9 +558,9 @@
                     </ScrollViewer>
                 </Grid>
 
-                <Separator Canvas.Top="153.15" Style="{StaticResource HidingGridSeparators}"/>
+                <Separator Canvas.Top="153" Style="{StaticResource HidingGridSeparators}"/>
 
-                <Grid Canvas.Top="153" Style="{StaticResource NotAGalaxyExample}">
+                <Grid Canvas.Top="154" Style="{StaticResource NotAGalaxyExample}">
                     <Grid.RenderTransform>
                         <TranslateTransform/>
                     </Grid.RenderTransform>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -26,7 +26,7 @@
         </Storyboard>
 
         <Storyboard x:Key="BeginRotateArrowStoryboard">
-            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[0].(RotateTransform.Angle)" To="180" Duration="0:0:0.1"/>
+            <DoubleAnimation BeginTime="0:0:0.1" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[0].(RotateTransform.Angle)" To="180" Duration="0:0:0.1"/>
         </Storyboard>
 
         <Storyboard x:Key="ReturnRotateArrowStoryboard">
@@ -34,7 +34,7 @@
         </Storyboard>
 
         <Storyboard x:Key="MoveArrowLeftStoryboard">
-            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)" To="-35" Duration="0:0:0.1"/>
+            <DoubleAnimation BeginTime="0:0:0.1" Storyboard.TargetProperty="(fa:ImageAwesome.RenderTransform).(TransformGroup.Children)[1].(TranslateTransform.X)" To="-18" Duration="0:0:0.1"/>
         </Storyboard>        
         
         <Storyboard x:Key="MoveArrowRightStoryboard">
@@ -42,7 +42,7 @@
         </Storyboard>
 
         <Storyboard x:Key="MoveToggleTextRight">
-            <DoubleAnimation BeginTime="0:0:0.18" Storyboard.TargetProperty="(TextBlock.RenderTransform).(TranslateTransform.X)" To="8" Duration="0:0:0.1"/>
+            <DoubleAnimation BeginTime="0:0:0.1" Storyboard.TargetProperty="(TextBlock.RenderTransform).(TranslateTransform.X)" To="8" Duration="0:0:0.1"/>
         </Storyboard>
 
         <Storyboard x:Key="MoveToggleTextLeft">
@@ -291,7 +291,7 @@
         </Style>
 
         <Style x:Key="ScrollableStackPanel" TargetType="{x:Type StackPanel}">
-            <Setter Property="Margin" Value="18,0,0,0"/>
+            <Setter Property="Margin" Value="18,6,0,0"/>
             <Setter Property="Orientation" Value="Horizontal"/>
             <Setter Property="Height" Value="Auto"/>
         </Style>
@@ -299,7 +299,7 @@
         <Style x:Key="ExampleGrid" TargetType="{x:Type Grid}">
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Margin" Value="18,0,14,0"/>
-            <Setter Property="Height" Value="10"/>
+            <Setter Property="Height" Value="16"/>
             <Setter Property="Background" Value="{StaticResource MedGrayColor}"/>
         </Style>
 
@@ -378,9 +378,11 @@
             <Setter Property="FontSize" Value="6.75"/>
             <Setter Property="VerticalAlignment" Value="Bottom"/>
             <Setter Property="Typography.Capitals" Value="AllSmallCaps"/>
+            <Setter Property="Text" Value="More Info"/>
 
             <Style.Triggers>
                 <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
+                    <Setter Property="Text" Value="Back"/>
                     <DataTrigger.EnterActions>
                         <BeginStoryboard Storyboard="{StaticResource MoveToggleTextRight}"/>
                     </DataTrigger.EnterActions>
@@ -438,7 +440,7 @@
 
                 <Separator Canvas.Top="36.15" Style="{StaticResource GridSeparators}"/>
 
-                <Grid Canvas.Top="44" Style="{StaticResource SmoothExample}">
+                <Grid Canvas.Top="38" Style="{StaticResource SmoothExample}">
                     <i:Interaction.Triggers>
                         <Lib:HandlingEventTrigger EventName="TouchUp">
                             <i:InvokeCommandAction Command="{Binding SelectItem}" CommandParameter="{Binding Smooth}"/>
@@ -454,7 +456,7 @@
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Smooth"/>
                         <StackPanel Style="{StaticResource ToggleStackPanel}">
-                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                            <TextBlock Style="{StaticResource ToggleText}">
                                 <TextBlock.RenderTransform>
                                     <TranslateTransform/>
                                 </TextBlock.RenderTransform>
@@ -496,7 +498,7 @@
 
                 <Separator Canvas.Top="96.15" Style="{StaticResource HidingGridSeparators}"/>
 
-                <Grid Canvas.Top="101.2" Style="{StaticResource FeaturesExample}">
+                <Grid Canvas.Top="95" Style="{StaticResource FeaturesExample}">
                     <Grid.RenderTransform>
                         <TranslateTransform/>
                     </Grid.RenderTransform>
@@ -516,7 +518,7 @@
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Features"/>
                         <StackPanel Style="{StaticResource ToggleStackPanel}">
-                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                            <TextBlock Style="{StaticResource ToggleText}">
                                 <TextBlock.RenderTransform>
                                     <TranslateTransform/>
                                 </TextBlock.RenderTransform>
@@ -558,7 +560,7 @@
 
                 <Separator Canvas.Top="153.15" Style="{StaticResource HidingGridSeparators}"/>
 
-                <Grid Canvas.Top="159.2" Style="{StaticResource NotAGalaxyExample}">
+                <Grid Canvas.Top="153" Style="{StaticResource NotAGalaxyExample}">
                     <Grid.RenderTransform>
                         <TranslateTransform/>
                     </Grid.RenderTransform>
@@ -578,7 +580,7 @@
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Not a Galaxy"/>
                         <StackPanel Style="{StaticResource ToggleStackPanel}">
-                            <TextBlock Style="{StaticResource ToggleText}" Text="More Info">
+                            <TextBlock Style="{StaticResource ToggleText}">
                                 <TextBlock.RenderTransform>
                                     <TranslateTransform/>
                                 </TextBlock.RenderTransform>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Leveler.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Leveler.xaml
@@ -13,18 +13,18 @@
     <UserControl.Resources>
         <Style x:Key="LevelerPanelStyle" TargetType="{x:Type Border}">
             <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=IsOpen}" Value="True">
+                <DataTrigger Binding="{Binding Path=IsOpen}" Value="False">
                     <DataTrigger.EnterActions>
                         <BeginStoryboard>
                             <Storyboard>
-                                <DoubleAnimation Storyboard.TargetProperty="(Panel.RenderTransform).(TranslateTransform.X)" To="0" Duration="0:0:0:0.2"/>
+                                <DoubleAnimation Storyboard.TargetProperty="(Panel.RenderTransform).(TranslateTransform.X)" Duration="0:0:0:0.2"/>
                             </Storyboard>
                         </BeginStoryboard>
                     </DataTrigger.EnterActions>
                     <DataTrigger.ExitActions>
                         <BeginStoryboard>
                             <Storyboard>
-                                <DoubleAnimation Storyboard.TargetProperty="(Panel.RenderTransform).(TranslateTransform.X)" Duration="0:0:0:0.2"/>
+                                <DoubleAnimation Storyboard.TargetProperty="(Panel.RenderTransform).(TranslateTransform.X)" To="0" Duration="0:0:0:0.2"/>
                             </Storyboard>
                         </BeginStoryboard>
                     </DataTrigger.ExitActions>


### PR DESCRIPTION
This PR fixes a few minor bugs we noticed when testing the touch table on the floor.

- Resets the leveler count when the classifier closes, which wasn't the previous behavior.
- Decreases time to see the "Still There?" modal from 5 to 3 minutes.
- On the classification summary view, sets a minimum width for a progress bar. A bug can occur when there are 25 classifications for a subject, but one answer only has one vote. However, most of the work to prevent this from happening will have to be set up in Caesar/Panoptes with retirement rules to prevent more than 25 classifications from submitting.
- Increases the hit area to toggle off an example on the right examples panel.
- Changes the wording and animations of the header for each example on the examples panel.