### PR TITLE
Add UI for User Rings over Subjects

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -88,12 +88,14 @@
     <Compile Include="Extensions\NotifyPropertyChangedExtensions.cs" />
     <Compile Include="Mock\GraphQLServiceMockData.cs" />
     <Compile Include="Mock\PanoptesServiceMockData.cs" />
+    <Compile Include="Models\TableSubjectTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\CenterpieceViewModelTests.cs" />
     <Compile Include="ViewModels\ClassificationPanelViewModelTests.cs" />
     <Compile Include="ViewModels\ExamplesPanelViewModelTests.cs" />
     <Compile Include="ViewModels\LevelerViewModelTests.cs" />
     <Compile Include="ViewModels\NotificationsViewModelTests.cs" />
+    <Compile Include="ViewModels\SpaceViewModelTests.cs" />
     <Compile Include="ViewModels\StillThereViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
@@ -1,0 +1,52 @@
+﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Models;
+using GalaxyZooTouchTable.Tests.Mock;
+using PanoptesNetClient.Models;
+using Xunit;
+
+namespace GalaxyZooTouchTable.Tests.Models
+{
+    public class TableSubjectTests
+    {
+        private TableSubject _tableSubject { get; set; }
+
+        public TableSubjectTests()
+        {
+            Subject _subject = PanoptesServiceMockData.Subject();
+            _tableSubject = new TableSubject(_subject, 0, 0);
+
+            _tableSubject.GalaxyRings.Add(new GalaxyRing(1, GlobalData.GetInstance().StarUser));
+            _tableSubject.GalaxyRings.Add(new GalaxyRing(2, GlobalData.GetInstance().EarthUser));
+        }
+
+        [Fact]
+        private void ShouldRemoveRing()
+        {
+            Assert.Equal(3, _tableSubject.GalaxyRings.Count);
+            _tableSubject.RemoveRing(GlobalData.GetInstance().StarUser);
+            Assert.Equal(2, _tableSubject.GalaxyRings.Count);
+        }
+
+        [Fact]
+        private void ShouldMarkARingAsClassified()
+        {
+            _tableSubject.DimRing(GlobalData.GetInstance().EarthUser);
+            GalaxyRing EarthRing;
+            foreach (GalaxyRing Ring in _tableSubject.GalaxyRings)
+            {
+                if (Ring.User == GlobalData.GetInstance().EarthUser)
+                {
+                    EarthRing = Ring;
+                    Assert.False(EarthRing.CurrentlyClassifying);
+                }
+            }
+        }
+
+        [Fact]
+        private void ShouldAddARing()
+        {
+            _tableSubject.AddRing(GlobalData.GetInstance().LightUser);
+            Assert.Equal(4, _tableSubject.GalaxyRings.Count);
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
@@ -34,7 +34,7 @@ namespace GalaxyZooTouchTable.Tests.Models
             GalaxyRing EarthRing;
             foreach (GalaxyRing Ring in _tableSubject.GalaxyRings)
             {
-                if (Ring.User == GlobalData.GetInstance().EarthUser)
+                if (Ring.UserName == GlobalData.GetInstance().EarthUser.Name)
                 {
                     EarthRing = Ring;
                     Assert.False(EarthRing.CurrentlyClassifying);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -1,0 +1,34 @@
+﻿using GalaxyZooTouchTable.Services;
+using GalaxyZooTouchTable.ViewModels;
+using Moq;
+using System.Collections.Specialized;
+using Xunit;
+
+namespace GalaxyZooTouchTable.Tests.ViewModels
+{
+    public class SpaceViewModelTests
+    {
+        private SpaceViewModel _viewModel { get; set; }
+        private Mock<IPanoptesService> _panoptesServiceMock = new Mock<IPanoptesService>();
+        private NameValueCollection _query;
+
+        public SpaceViewModelTests()
+        {
+            _query = new NameValueCollection
+                {
+                    { "workflow_id", "1" },
+                    { "page_size", "25" }
+                };
+
+            _viewModel = new SpaceViewModel(_panoptesServiceMock.Object);
+        }
+
+        [Fact]
+        private void ShouldInitializeWithDefaultValues()
+        {
+            Assert.NotNull(_viewModel.CurrentGalaxies);
+            Assert.NotNull(_viewModel.SpaceCutoutUrl);
+            _panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", _query), Times.Once);
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -27,7 +27,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>4</ApplicationRevision>
+    <ApplicationRevision>7</ApplicationRevision>
     <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -186,7 +186,7 @@
     <Compile Include="Lib\NotificationStatus.cs" />
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />
-    <Compile Include="Models\ClassificationRingCreator.cs" />
+    <Compile Include="Models\ClassificationRingNotifier.cs" />
     <Compile Include="Models\GalaxyRing.cs" />
     <Compile Include="Models\IClassificationPanelViewModelFactory.cs" />
     <Compile Include="Lib\SubjectViewEnum.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Lib\GridLengthAnimation.cs" />
     <Compile Include="Lib\NotificationStatus.cs" />
     <Compile Include="Lib\Messenger.cs" />
+    <Compile Include="Lib\RingNotifierStatus.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />
     <Compile Include="Models\ClassificationRingNotifier.cs" />
     <Compile Include="Models\GalaxyRing.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />
     <Compile Include="Models\ClassificationRingCreator.cs" />
+    <Compile Include="Models\GalaxyRing.cs" />
     <Compile Include="Models\IClassificationPanelViewModelFactory.cs" />
     <Compile Include="Lib\SubjectViewEnum.cs" />
     <Compile Include="Models\NotificationRequest.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Lib\NotificationStatus.cs" />
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />
+    <Compile Include="Models\ClassificationRingCreator.cs" />
     <Compile Include="Models\IClassificationPanelViewModelFactory.cs" />
     <Compile Include="Lib\SubjectViewEnum.cs" />
     <Compile Include="Models\NotificationRequest.cs" />
@@ -229,6 +230,9 @@
     <Compile Include="Models\GalaxyExample.cs" />
     <Compile Include="Models\TableUserFactory.cs" />
     <Compile Include="Converters\NullImageConverter.cs" />
+    <Compile Include="Views\GalaxyTileView.xaml.cs">
+      <DependentUpon>GalaxyTileView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\Leveler.xaml.cs">
       <DependentUpon>Leveler.xaml</DependentUpon>
     </Compile>
@@ -352,6 +356,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\DropZone.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\GalaxyTileView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/RingNotifierStatus.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/RingNotifierStatus.cs
@@ -3,12 +3,14 @@
     /// <summary>
     /// IsCreating: User is beginning to classify a galaxy and a ring should be created
     /// IsSubmitting: User is submitting a classification and a ring should be dimmed
+    /// IsHelping: User is changing subjects due to helping a neighbor and active ring should be changed
     /// IsLeaving: User is leaving the table and a ring should be removed
     /// </summary>
     public enum RingNotifierStatus
     {
         IsCreating,
         IsSubmitting,
+        IsHelping,
         IsLeaving
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/RingNotifierStatus.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/RingNotifierStatus.cs
@@ -1,0 +1,14 @@
+﻿namespace GalaxyZooTouchTable.Lib
+{
+    /// <summary>
+    /// IsCreating: User is beginning to classify a galaxy and a ring should be created
+    /// IsSubmitting: User is submitting a classification and a ring should be dimmed
+    /// IsLeaving: User is leaving the table and a ring should be removed
+    /// </summary>
+    public enum RingNotifierStatus
+    {
+        IsCreating,
+        IsSubmitting,
+        IsLeaving
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingCreator.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingCreator.cs
@@ -1,0 +1,16 @@
+﻿using PanoptesNetClient.Models;
+
+namespace GalaxyZooTouchTable.Models
+{
+    public class ClassificationRingCreator
+    {
+        public TableUser User { get; set; }
+        public Subject Subject { get; set; }
+
+        public ClassificationRingCreator(Subject subject, TableUser user)
+        {
+            Subject = subject;
+            User = user;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
@@ -11,8 +11,8 @@ namespace GalaxyZooTouchTable.Models
 
         public ClassificationRingNotifier(Subject subject, TableUser user, RingNotifierStatus status)
         {
+            SubjectId = subject != null ? subject.Id : null;
             Status = status;
-            SubjectId = subject.Id;
             User = user;
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
@@ -1,16 +1,17 @@
-﻿using PanoptesNetClient.Models;
+﻿using GalaxyZooTouchTable.Lib;
+using PanoptesNetClient.Models;
 
 namespace GalaxyZooTouchTable.Models
 {
     public class ClassificationRingNotifier
     {
-        public TableUser User { get; set; }
-        public Subject Subject { get; set; }
-        public bool IsCreating { get; set; }
+        public TableUser User { get; private set; }
+        public Subject Subject { get; private set; }
+        public RingNotifierStatus Status { get; set; }
 
-        public ClassificationRingNotifier(Subject subject, TableUser user, bool isCreating)
+        public ClassificationRingNotifier(Subject subject, TableUser user, RingNotifierStatus status)
         {
-            IsCreating = isCreating;
+            Status = status;
             Subject = subject;
             User = user;
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
@@ -2,13 +2,15 @@
 
 namespace GalaxyZooTouchTable.Models
 {
-    public class ClassificationRingCreator
+    public class ClassificationRingNotifier
     {
         public TableUser User { get; set; }
         public Subject Subject { get; set; }
+        public bool IsCreating { get; set; }
 
-        public ClassificationRingCreator(Subject subject, TableUser user)
+        public ClassificationRingNotifier(Subject subject, TableUser user, bool isCreating)
         {
+            IsCreating = isCreating;
             Subject = subject;
             User = user;
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
@@ -6,13 +6,13 @@ namespace GalaxyZooTouchTable.Models
     public class ClassificationRingNotifier
     {
         public TableUser User { get; private set; }
-        public Subject Subject { get; private set; }
+        public string SubjectId { get; private set; }
         public RingNotifierStatus Status { get; set; }
 
         public ClassificationRingNotifier(Subject subject, TableUser user, RingNotifierStatus status)
         {
             Status = status;
-            Subject = subject;
+            SubjectId = subject.Id;
             User = user;
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -1,8 +1,9 @@
-﻿using System.Windows.Media.Imaging;
+﻿using GalaxyZooTouchTable.ViewModels;
+using System.Windows.Media.Imaging;
 
 namespace GalaxyZooTouchTable.Models
 {
-    public class GalaxyRing
+    public class GalaxyRing : ViewModelBase
     {
         const int RING_WIDTH_STEP = 16;
         const int INITIAL_RING_WIDTH = 56;
@@ -16,9 +17,18 @@ namespace GalaxyZooTouchTable.Models
         public int AvatarY { get; set; }
         public string UserColor { get; set; }
         public int YPos { get; set; }
+        public TableUser User { get; private set; }
+
+        private bool _currentlyClassifying = true;
+        public bool CurrentlyClassifying
+        {
+            get => _currentlyClassifying;
+            set => SetProperty(ref _currentlyClassifying, value);
+        }
 
         public GalaxyRing(int index, TableUser user)
         {
+            User = user;
             UserColor = user.ThemeColor;
             UserAvatar = user.Avatar;
             GetProperties(index);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -96,27 +96,5 @@ namespace GalaxyZooTouchTable.Models
                 }
             }
         }
-
-        //private void AvatarRotation(int index)
-        //{
-        //    var RotationStart = index + 1;
-        //    var Remainder = RotationStart % 4;
-
-        //    switch (Remainder)
-        //    {
-        //        case 1:
-        //            AvatarX = AvatarX * -1;
-        //            break;
-        //        case 2:
-        //            AvatarX = AvatarX * -1;
-        //            AvatarY = AvatarY * -1;
-        //            break;
-        //        case 3:
-        //            AvatarY = AvatarY * -1;
-        //            break;
-        //        default:
-        //            break;
-        //    }
-        //}
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -8,16 +8,31 @@ namespace GalaxyZooTouchTable.Models
         const int RING_WIDTH_STEP = 16;
         const int INITIAL_RING_WIDTH = 56;
         const int INITIAL_AVATAR_RADIUS_POSITION = 20;
-        const int INITIAL_RADIUS = 28;
 
-        public int Diameter { get; set; }
-        public int CornerRadius { get; set; }
         public BitmapImage UserAvatar { get; set; }
-        public int AvatarX { get; set; }
-        public int AvatarY { get; set; }
         public string UserColor { get; set; } = "#E5FF4D";
-        public int YPos { get; set; }
         public TableUser User { get; private set; }
+
+        private int _avatarX = 0;
+        public int AvatarX
+        {
+            get => _avatarX;
+            set => SetProperty(ref _avatarX, value);
+        }
+
+        private int _avatarY = 0;
+        public int AvatarY
+        {
+            get => _avatarY;
+            set => SetProperty(ref _avatarY, value);
+        }
+
+        private int _diameter = 0;
+        public int Diameter
+        {
+            get => _diameter;
+            set => SetProperty(ref _diameter, value);
+        }
 
         private bool _currentlyClassifying = true;
         public bool CurrentlyClassifying
@@ -34,47 +49,74 @@ namespace GalaxyZooTouchTable.Models
                 UserColor = user.ThemeColor;
                 UserAvatar = user.Avatar;
             }
-            GetProperties(index);
+            SetProperties(index);
         }
 
-        private void GetProperties(int index)
+        public void SetProperties(int index)
         {
             Diameter = INITIAL_RING_WIDTH + (RING_WIDTH_STEP * index);
-            CornerRadius = Diameter / 2;
             AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
             AvatarY = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
-            YPos = index == 0 ? 0 : (Diameter) * -1;
 
-            AvatarRotation(index);
+            AvatarPlacement();
 
             var position = 0;
             for (var start = 0; start < index; start++)
             {
                 position -= (Diameter - (8 * index));
             }
-            YPos = position;
         }
 
-        private void AvatarRotation(int index)
+        private void AvatarPlacement()
         {
-            var RotationStart = index + 1;
-            var Remainder = RotationStart % 4;
-
-            switch (Remainder)
+            if (User != null)
             {
-                case 1:
-                    AvatarX = AvatarX * -1;
-                    break;
-                case 2:
-                    AvatarX = AvatarX * -1;
-                    AvatarY = AvatarY * -1;
-                    break;
-                case 3:
-                    AvatarY = AvatarY * -1;
-                    break;
-                default:
-                    break;
+                switch (User.Name)
+                {
+                    case "HeartUser":
+                        AvatarY *= -1;
+                        AvatarX *= -1;
+                        break;
+                    case "StarUser":
+                        AvatarY *= -1;
+                        break;
+                    case "LightUser":
+                        AvatarY = 0;
+                        AvatarX = Diameter / 2;
+                        break;
+                    case "PersonUser":
+                        AvatarX *= -1;
+                        break;
+                    case "EarthUser":
+                        AvatarY = 0;
+                        AvatarX = Diameter / 2 * -1;
+                        break;
+                    default:
+                        break;
+                }
             }
         }
+
+        //private void AvatarRotation(int index)
+        //{
+        //    var RotationStart = index + 1;
+        //    var Remainder = RotationStart % 4;
+
+        //    switch (Remainder)
+        //    {
+        //        case 1:
+        //            AvatarX = AvatarX * -1;
+        //            break;
+        //        case 2:
+        //            AvatarX = AvatarX * -1;
+        //            AvatarY = AvatarY * -1;
+        //            break;
+        //        case 3:
+        //            AvatarY = AvatarY * -1;
+        //            break;
+        //        default:
+        //            break;
+        //    }
+        //}
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -15,7 +15,7 @@ namespace GalaxyZooTouchTable.Models
         public BitmapImage UserAvatar { get; set; }
         public int AvatarX { get; set; }
         public int AvatarY { get; set; }
-        public string UserColor { get; set; }
+        public string UserColor { get; set; } = "#E5FF4D";
         public int YPos { get; set; }
         public TableUser User { get; private set; }
 
@@ -26,11 +26,14 @@ namespace GalaxyZooTouchTable.Models
             set => SetProperty(ref _currentlyClassifying, value);
         }
 
-        public GalaxyRing(int index, TableUser user)
+        public GalaxyRing(int index = 0, TableUser user = null)
         {
-            User = user;
-            UserColor = user.ThemeColor;
-            UserAvatar = user.Avatar;
+            if (user != null)
+            {
+                User = user;
+                UserColor = user.ThemeColor;
+                UserAvatar = user.Avatar;
+            }
             GetProperties(index);
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -12,7 +12,7 @@ namespace GalaxyZooTouchTable.Models
 
         public BitmapImage UserAvatar { get; set; }
         public string UserColor { get; set; } = "#E5FF4D";
-        public TableUser User { get; private set; }
+        public string UserName { get; set; }
 
         private int _avatarX = 0;
         public int AvatarX
@@ -46,7 +46,7 @@ namespace GalaxyZooTouchTable.Models
         {
             if (user != null)
             {
-                User = user;
+                UserName = user.Name;
                 UserColor = user.ThemeColor;
                 UserAvatar = user.Avatar;
             }
@@ -59,14 +59,14 @@ namespace GalaxyZooTouchTable.Models
             AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * (AVATAR_WIDTH_STEP));
             AvatarY = INITIAL_AVATAR_RADIUS_POSITION + (index * (AVATAR_WIDTH_STEP));
 
-            AvatarPlacement();
+            PlaceAvatar();
         }
 
-        private void AvatarPlacement()
+        private void PlaceAvatar()
         {
-            if (User != null)
+            if (UserName != null)
             {
-                switch (User.Name)
+                switch (UserName)
                 {
                     case "HeartUser":
                         AvatarY *= -1;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -1,0 +1,43 @@
+﻿using System.Windows.Media.Imaging;
+
+namespace GalaxyZooTouchTable.Models
+{
+    public class GalaxyRing
+    {
+        const int RING_WIDTH_STEP = 16;
+        const int INITIAL_RING_WIDTH = 56;
+        const int INITIAL_AVATAR_RADIUS_POSITION = 26;
+        const int INITIAL_RADIUS = 28;
+
+        public int Diameter { get; set; }
+        public int CornerRadius { get; set; }
+        public BitmapImage UserAvatar { get; set; }
+        public int AvatarX { get; set; }
+        public int AvatarY { get; set; }
+        public string UserColor { get; set; }
+        public int YPos { get; set; }
+
+        public GalaxyRing(int index, TableUser user)
+        {
+            UserColor = user.ThemeColor;
+            UserAvatar = user.Avatar;
+            GetProperties(index);
+        }
+
+        private void GetProperties(int index)
+        {
+            Diameter = INITIAL_RING_WIDTH + (RING_WIDTH_STEP * index);
+            CornerRadius = Diameter / 2;
+            AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * RING_WIDTH_STEP);
+            YPos = index == 0 ? 0 : (Diameter) * -1;
+            var test = ((INITIAL_RING_WIDTH * index) + Diameter) * -1;
+
+            var position = 0;
+            for (var start = 0; start < index; start++)
+            {
+                position -= (Diameter - (8 * index));
+            }
+            YPos = position;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -6,7 +6,7 @@ namespace GalaxyZooTouchTable.Models
     {
         const int RING_WIDTH_STEP = 16;
         const int INITIAL_RING_WIDTH = 56;
-        const int INITIAL_AVATAR_RADIUS_POSITION = 26;
+        const int INITIAL_AVATAR_RADIUS_POSITION = 20;
         const int INITIAL_RADIUS = 28;
 
         public int Diameter { get; set; }
@@ -28,9 +28,11 @@ namespace GalaxyZooTouchTable.Models
         {
             Diameter = INITIAL_RING_WIDTH + (RING_WIDTH_STEP * index);
             CornerRadius = Diameter / 2;
-            AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * RING_WIDTH_STEP);
+            AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
+            AvatarY = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
             YPos = index == 0 ? 0 : (Diameter) * -1;
-            var test = ((INITIAL_RING_WIDTH * index) + Diameter) * -1;
+
+            AvatarRotation(index);
 
             var position = 0;
             for (var start = 0; start < index; start++)
@@ -38,6 +40,28 @@ namespace GalaxyZooTouchTable.Models
                 position -= (Diameter - (8 * index));
             }
             YPos = position;
+        }
+
+        private void AvatarRotation(int index)
+        {
+            var RotationStart = index + 1;
+            var Remainder = RotationStart % 4;
+
+            switch (Remainder)
+            {
+                case 1:
+                    AvatarX = AvatarX * -1;
+                    break;
+                case 2:
+                    AvatarX = AvatarX * -1;
+                    AvatarY = AvatarY * -1;
+                    break;
+                case 3:
+                    AvatarY = AvatarY * -1;
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/GalaxyRing.cs
@@ -6,6 +6,7 @@ namespace GalaxyZooTouchTable.Models
     public class GalaxyRing : ViewModelBase
     {
         const int RING_WIDTH_STEP = 16;
+        const int AVATAR_WIDTH_STEP = 6;
         const int INITIAL_RING_WIDTH = 56;
         const int INITIAL_AVATAR_RADIUS_POSITION = 20;
 
@@ -55,16 +56,10 @@ namespace GalaxyZooTouchTable.Models
         public void SetProperties(int index)
         {
             Diameter = INITIAL_RING_WIDTH + (RING_WIDTH_STEP * index);
-            AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
-            AvatarY = INITIAL_AVATAR_RADIUS_POSITION + (index * (6));
+            AvatarX = INITIAL_AVATAR_RADIUS_POSITION + (index * (AVATAR_WIDTH_STEP));
+            AvatarY = INITIAL_AVATAR_RADIUS_POSITION + (index * (AVATAR_WIDTH_STEP));
 
             AvatarPlacement();
-
-            var position = 0;
-            for (var start = 0; start < index; start++)
-            {
-                position -= (Diameter - (8 * index));
-            }
         }
 
         private void AvatarPlacement()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/NotificationRequest.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/NotificationRequest.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GalaxyZooTouchTable.Models
+﻿namespace GalaxyZooTouchTable.Models
 {
     public class NotificationRequest
     {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -14,7 +14,14 @@ namespace GalaxyZooTouchTable.Models
         private readonly double PlateScale = 1.5;
         private readonly double Offset = 0.03;
         public Subject Subject { get; set; }
-        public ObservableCollection<TableUser> Submissions { get; set; } = new ObservableCollection<TableUser>();
+        public ObservableCollection<GalaxyRing> Submissions { get; set; } = new ObservableCollection<GalaxyRing>();
+
+        private int _tileOffset = -28;
+        public int TileOffset
+        {
+            get => _tileOffset;
+            set => SetProperty(ref _tileOffset, value);
+        }
 
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
@@ -43,7 +50,13 @@ namespace GalaxyZooTouchTable.Models
 
         public void AddRing(TableUser user)
         {
-            Submissions.Add(user);
+            int NewIndex = Submissions.Count;
+            GalaxyRing NewRing = new GalaxyRing(NewIndex, user);
+            if (NewIndex > 0)
+            {
+                TileOffset -= 8;
+            }
+            Submissions.Add(NewRing);
         }
 
         private double ToRadians(double Degrees)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -50,7 +50,7 @@ namespace GalaxyZooTouchTable.Models
             bool RingRemoved = false;
             foreach (GalaxyRing Ring in GalaxyRings)
             {
-                if (Ring.User == user)
+                if (Ring.UserName == user.Name)
                 {
                     GalaxyRings.Remove(Ring);
                     RingRemoved = true;
@@ -73,7 +73,7 @@ namespace GalaxyZooTouchTable.Models
         {
             foreach (GalaxyRing Ring in GalaxyRings)
             {
-                if (Ring.User == userClassifying)
+                if (Ring.UserName == userClassifying.Name)
                 {
                     Ring.CurrentlyClassifying = false;
                 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -13,7 +13,7 @@ namespace GalaxyZooTouchTable.Models
         private readonly double Offset = 0.03;
         public Subject Subject { get; set; }
 
-        public TableSubject(Subject subject, double TableRA, double TableDEC)
+        public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
             RightAscension = System.Convert.ToDouble(subject.Metadata.ra);
             Declination = System.Convert.ToDouble(subject.Metadata.dec);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -58,11 +58,14 @@ namespace GalaxyZooTouchTable.Models
                 }
             }
 
-            int index = 0;
-            foreach (GalaxyRing Ring in Submissions)
+            if (RingRemoved)
             {
-                Ring.SetProperties(index);
-                index++;
+                int index = 0;
+                foreach (GalaxyRing Ring in Submissions)
+                {
+                    Ring.SetProperties(index);
+                    index++;
+                }
             }
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -31,6 +31,8 @@ namespace GalaxyZooTouchTable.Models
             Subject = subject;
             SubjectLocation = subject.GetSubjectLocation();
             XYConvert(TableRA, TableDEC);
+
+            Submissions.Add(new GalaxyRing());
         }
 
         private void XYConvert(double CenterRightAscension, double CenterDeclination)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -18,13 +18,6 @@ namespace GalaxyZooTouchTable.Models
         public Subject Subject { get; set; }
         public ObservableCollection<GalaxyRing> Submissions { get; set; } = new ObservableCollection<GalaxyRing>();
 
-        private int _tileOffset = -28;
-        public int TileOffset
-        {
-            get => _tileOffset;
-            set => SetProperty(ref _tileOffset, value);
-        }
-
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
             RightAscension = System.Convert.ToDouble(subject.Metadata.ra);
@@ -54,13 +47,22 @@ namespace GalaxyZooTouchTable.Models
 
         public void RemoveRing(TableUser user)
         {
+            bool RingRemoved = false;
             foreach (GalaxyRing Ring in Submissions)
             {
                 if (Ring.User == user)
                 {
                     Submissions.Remove(Ring);
+                    RingRemoved = true;
                     break;
                 }
+            }
+
+            int index = 0;
+            foreach (GalaxyRing Ring in Submissions)
+            {
+                Ring.SetProperties(index);
+                index++;
             }
         }
 
@@ -79,10 +81,6 @@ namespace GalaxyZooTouchTable.Models
         {
             int NewIndex = Submissions.Count;
             GalaxyRing NewRing = new GalaxyRing(NewIndex, user);
-            if (NewIndex > 0)
-            {
-                TileOffset -= 8;
-            }
             Submissions.Add(NewRing);
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,12 +1,9 @@
-﻿using System;
+﻿using PanoptesNetClient.Models;
 using System.Collections.ObjectModel;
-using System.Linq;
-using GalaxyZooTouchTable.ViewModels;
-using PanoptesNetClient.Models;
 
 namespace GalaxyZooTouchTable.Models
 {
-    public class TableSubject : ViewModelBase
+    public class TableSubject
     {
         public int X { get; set; }
         public int Y { get; set; }
@@ -16,7 +13,7 @@ namespace GalaxyZooTouchTable.Models
         private readonly double PlateScale = 1.5;
         private readonly double Offset = 0.03;
         public Subject Subject { get; set; }
-        public ObservableCollection<GalaxyRing> Submissions { get; set; } = new ObservableCollection<GalaxyRing>();
+        public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
 
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
@@ -26,7 +23,7 @@ namespace GalaxyZooTouchTable.Models
             SubjectLocation = subject.GetSubjectLocation();
             XYConvert(TableRA, TableDEC);
 
-            Submissions.Add(new GalaxyRing());
+            GalaxyRings.Add(new GalaxyRing());
         }
 
         private void XYConvert(double CenterRightAscension, double CenterDeclination)
@@ -48,11 +45,11 @@ namespace GalaxyZooTouchTable.Models
         public void RemoveRing(TableUser user)
         {
             bool RingRemoved = false;
-            foreach (GalaxyRing Ring in Submissions)
+            foreach (GalaxyRing Ring in GalaxyRings)
             {
                 if (Ring.User == user)
                 {
-                    Submissions.Remove(Ring);
+                    GalaxyRings.Remove(Ring);
                     RingRemoved = true;
                     break;
                 }
@@ -61,7 +58,7 @@ namespace GalaxyZooTouchTable.Models
             if (RingRemoved)
             {
                 int index = 0;
-                foreach (GalaxyRing Ring in Submissions)
+                foreach (GalaxyRing Ring in GalaxyRings)
                 {
                     Ring.SetProperties(index);
                     index++;
@@ -71,7 +68,7 @@ namespace GalaxyZooTouchTable.Models
 
         public void DimRing(TableUser userClassifying)
         {
-            foreach (GalaxyRing Ring in Submissions)
+            foreach (GalaxyRing Ring in GalaxyRings)
             {
                 if (Ring.User == userClassifying)
                 {
@@ -82,9 +79,9 @@ namespace GalaxyZooTouchTable.Models
 
         public void AddRing(TableUser user)
         {
-            int NewIndex = Submissions.Count;
+            int NewIndex = GalaxyRings.Count;
             GalaxyRing NewRing = new GalaxyRing(NewIndex, user);
-            Submissions.Add(NewRing);
+            GalaxyRings.Add(NewRing);
         }
 
         private double ToRadians(double Degrees)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,8 +1,10 @@
-﻿using PanoptesNetClient.Models;
+﻿using System.Collections.ObjectModel;
+using GalaxyZooTouchTable.ViewModels;
+using PanoptesNetClient.Models;
 
 namespace GalaxyZooTouchTable.Models
 {
-    public class TableSubject
+    public class TableSubject : ViewModelBase
     {
         public int X { get; set; }
         public int Y { get; set; }
@@ -12,6 +14,7 @@ namespace GalaxyZooTouchTable.Models
         private readonly double PlateScale = 1.5;
         private readonly double Offset = 0.03;
         public Subject Subject { get; set; }
+        public ObservableCollection<TableUser> Submissions { get; set; } = new ObservableCollection<TableUser>();
 
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
@@ -36,6 +39,11 @@ namespace GalaxyZooTouchTable.Models
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);
+        }
+
+        public void AddRing(TableUser user)
+        {
+            Submissions.Add(user);
         }
 
         private double ToRadians(double Degrees)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -49,9 +49,15 @@ namespace GalaxyZooTouchTable.Models
             X = System.Convert.ToInt32(StartX);
         }
 
-        public void DimRing(TableUser user)
+        public void DimRing(TableUser userClassifying)
         {
-            throw new NotImplementedException();
+            foreach (GalaxyRing Ring in Submissions)
+            {
+                if (Ring.User == userClassifying)
+                {
+                    Ring.CurrentlyClassifying = false;
+                }
+            }
         }
 
         public void AddRing(TableUser user)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using GalaxyZooTouchTable.ViewModels;
 using PanoptesNetClient.Models;
 
@@ -49,6 +50,18 @@ namespace GalaxyZooTouchTable.Models
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);
+        }
+
+        public void RemoveRing(TableUser user)
+        {
+            foreach (GalaxyRing Ring in Submissions)
+            {
+                if (Ring.User == user)
+                {
+                    Submissions.Remove(Ring);
+                    break;
+                }
+            }
         }
 
         public void DimRing(TableUser userClassifying)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -17,8 +17,11 @@ namespace GalaxyZooTouchTable.Models
 
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
-            RightAscension = System.Convert.ToDouble(subject.Metadata.ra);
-            Declination = System.Convert.ToDouble(subject.Metadata.dec);
+            if (subject.Metadata != null)
+            {
+                RightAscension = System.Convert.ToDouble(subject.Metadata.ra);
+                Declination = System.Convert.ToDouble(subject.Metadata.dec);
+            }
             Subject = subject;
             SubjectLocation = subject.GetSubjectLocation();
             XYConvert(TableRA, TableDEC);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using GalaxyZooTouchTable.ViewModels;
 using PanoptesNetClient.Models;
 
@@ -46,6 +47,11 @@ namespace GalaxyZooTouchTable.Models
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);
+        }
+
+        public void DimRing(TableUser user)
+        {
+            throw new NotImplementedException();
         }
 
         public void AddRing(TableUser user)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -173,7 +173,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnSendRequestToUser(TableUser UserToNotify)
         {
-            NotificationRequest Request = new NotificationRequest(User, CurrentGalaxy.Subject.Id);
+            NotificationRequest Request = new NotificationRequest(User, CurrentSubject.Id);
             Messenger.Default.Send<NotificationRequest>(Request, $"{UserToNotify.Name}_ReceivedNotification");
         }
 
@@ -282,7 +282,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void NotifySpaceView(RingNotifierStatus Status)
         {
-            ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentGalaxy.Subject, User, Status);
+            ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentSubject, User, Status);
             Messenger.Default.Send<ClassificationRingNotifier>(Notification);
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -17,6 +17,7 @@ namespace GalaxyZooTouchTable.ViewModels
     {
         private IGraphQLService _graphQLService;
         private IPanoptesService _panoptesService;
+        private TableSubject CurrentGalaxy { get; set; }
         private string CurrentTaskIndex { get; set; }
         private DispatcherTimer StillThereTimer { get; set; }
 
@@ -172,7 +173,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnSendRequestToUser(TableUser UserToNotify)
         {
-            NotificationRequest Request = new NotificationRequest(User, CurrentSubject.Id);
+            NotificationRequest Request = new NotificationRequest(User, CurrentGalaxy.Subject.Id);
             Messenger.Default.Send<NotificationRequest>(Request, $"{UserToNotify.Name}_ReceivedNotification");
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -237,6 +237,7 @@ namespace GalaxyZooTouchTable.ViewModels
             ClassifierOpen = false;
             CloseConfirmationVisible = false;
             User.Active = false;
+            NotifySpaceView(RingNotifierStatus.IsLeaving);
         }
 
         private void PrepareForNewClassification()
@@ -260,8 +261,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (CurrentView == ClassifierViewEnum.SubjectView)
             {
-                bool IsCreating = false;
-                NotifySpaceView(IsCreating);
+                NotifySpaceView(RingNotifierStatus.IsSubmitting);
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
                 await _panoptesService.CreateClassificationAsync(CurrentClassification);
@@ -278,9 +278,9 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private void NotifySpaceView(bool IsCreating)
+        private void NotifySpaceView(RingNotifierStatus Status)
         {
-            ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentGalaxy.Subject, User, IsCreating);
+            ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentGalaxy.Subject, User, Status);
             Messenger.Default.Send<ClassificationRingNotifier>(Notification);
         }
 
@@ -393,8 +393,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Subjects.Insert(0, subject.Subject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
-            bool IsCreating = true;
-            NotifySpaceView(IsCreating);
+            NotifySpaceView(RingNotifierStatus.IsCreating);
         }
 
         public void ResetAnswerCount()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -260,6 +260,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (CurrentView == ClassifierViewEnum.SubjectView)
             {
+                NotifySpaceView();
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
                 await _panoptesService.CreateClassificationAsync(CurrentClassification);
@@ -274,6 +275,12 @@ namespace GalaxyZooTouchTable.ViewModels
             {
                 PrepareForNewClassification();
             }
+        }
+
+        private void NotifySpaceView()
+        {
+            ClassificationRingCreator Notification = new ClassificationRingCreator(CurrentGalaxy.Subject, User);
+            Messenger.Default.Send<ClassificationRingCreator>(Notification);
         }
 
         private void HandleNotificationsOnSubmit()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -209,11 +209,13 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public async void OnGetSubjectById(string subjectID)
         {
+            NotifySpaceView(RingNotifierStatus.IsHelping);
             TotalVotes = 0;
             Subject newSubject = await _panoptesService.GetSubjectAsync(subjectID);
             Subjects.Insert(0, newSubject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
+            NotifySpaceView(RingNotifierStatus.IsCreating);
         }
 
         private void OnOpenClassifier(object sender)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -260,6 +260,8 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (CurrentView == ClassifierViewEnum.SubjectView)
             {
+                bool IsCreating = false;
+                NotifySpaceView(IsCreating);
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
                 await _panoptesService.CreateClassificationAsync(CurrentClassification);
@@ -276,10 +278,10 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private void NotifySpaceView()
+        private void NotifySpaceView(bool IsCreating)
         {
-            ClassificationRingCreator Notification = new ClassificationRingCreator(CurrentGalaxy.Subject, User);
-            Messenger.Default.Send<ClassificationRingCreator>(Notification);
+            ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentGalaxy.Subject, User, IsCreating);
+            Messenger.Default.Send<ClassificationRingNotifier>(Notification);
         }
 
         private void HandleNotificationsOnSubmit()
@@ -391,7 +393,8 @@ namespace GalaxyZooTouchTable.ViewModels
             Subjects.Insert(0, subject.Subject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
-            NotifySpaceView();
+            bool IsCreating = true;
+            NotifySpaceView(IsCreating);
         }
 
         public void ResetAnswerCount()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -260,7 +260,6 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             if (CurrentView == ClassifierViewEnum.SubjectView)
             {
-                NotifySpaceView();
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
                 await _panoptesService.CreateClassificationAsync(CurrentClassification);
@@ -392,6 +391,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Subjects.Insert(0, subject.Subject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
+            NotifySpaceView();
         }
 
         public void ResetAnswerCount()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -38,7 +38,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                if (RingNotifier.Subject == SpaceViewGalaxy.Subject)
+                if (RingNotifier.Subject.Id == SpaceViewGalaxy.Subject.Id)
                 {
                     if (RingNotifier.Status == RingNotifierStatus.IsCreating)
                     {
@@ -46,6 +46,9 @@ namespace GalaxyZooTouchTable.ViewModels
                     } else if (RingNotifier.Status == RingNotifierStatus.IsSubmitting)
                     {
                         SpaceViewGalaxy.DimRing(RingNotifier.User);
+                    } else if (RingNotifier.Status == RingNotifierStatus.IsHelping)
+                    {
+                        SpaceViewGalaxy.RemoveRing(RingNotifier.User);
                     }
                 } else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
                 {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -40,13 +40,16 @@ namespace GalaxyZooTouchTable.ViewModels
             {
                 if (RingNotifier.Subject == SpaceViewGalaxy.Subject)
                 {
-                    if (RingNotifier.IsCreating)
+                    if (RingNotifier.Status == RingNotifierStatus.IsCreating)
                     {
                         SpaceViewGalaxy.AddRing(RingNotifier.User);
-                    } else
+                    } else if (RingNotifier.Status == RingNotifierStatus.IsSubmitting)
                     {
                         SpaceViewGalaxy.DimRing(RingNotifier.User);
                     }
+                } else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
+                {
+                    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
                 }
             }
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -31,16 +31,22 @@ namespace GalaxyZooTouchTable.ViewModels
         public SpaceViewModel()
         {
             PrepareForNewPosition();
-            Messenger.Default.Register<ClassificationRingCreator>(this, OnClassificationBegun);
+            Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
         }
 
-        private void OnClassificationBegun(ClassificationRingCreator RingCreator)
+        private void OnGalaxyInteraction(ClassificationRingNotifier RingNotifier)
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                if (RingCreator.Subject == SpaceViewGalaxy.Subject)
+                if (RingNotifier.Subject == SpaceViewGalaxy.Subject)
                 {
-                    SpaceViewGalaxy.AddRing(RingCreator.User);
+                    if (RingNotifier.IsCreating)
+                    {
+                        SpaceViewGalaxy.AddRing(RingNotifier.User);
+                    } else
+                    {
+                        SpaceViewGalaxy.DimRing(RingNotifier.User);
+                    }
                 }
             }
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -38,17 +38,21 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                if (RingNotifier.Subject.Id == SpaceViewGalaxy.Subject.Id)
+                if (RingNotifier.SubjectId == SpaceViewGalaxy.Subject.Id)
                 {
-                    if (RingNotifier.Status == RingNotifierStatus.IsCreating)
+                    switch (RingNotifier.Status)
                     {
-                        SpaceViewGalaxy.AddRing(RingNotifier.User);
-                    } else if (RingNotifier.Status == RingNotifierStatus.IsSubmitting)
-                    {
-                        SpaceViewGalaxy.DimRing(RingNotifier.User);
-                    } else if (RingNotifier.Status == RingNotifierStatus.IsHelping)
-                    {
-                        SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                        case RingNotifierStatus.IsCreating:
+                            SpaceViewGalaxy.AddRing(RingNotifier.User);
+                            break;
+                        case RingNotifierStatus.IsSubmitting:
+                            SpaceViewGalaxy.DimRing(RingNotifier.User);
+                            break;
+                        case RingNotifierStatus.IsHelping:
+                            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                            break;
+                        default:
+                            break;
                     }
                 } else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
                 {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.Models;
-using PanoptesNetClient;
+using GalaxyZooTouchTable.Services;
 using PanoptesNetClient.Models;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -10,11 +10,12 @@ namespace GalaxyZooTouchTable.ViewModels
 {
     public class SpaceViewModel : ViewModelBase
     {
+        private IPanoptesService _panoptesService;
         public double RA { get; set; } = 250.3035;
         public double DEC { get; set; } = 35.09;
         public double SCALE { get; set; } = 1.5;
 
-        public List<TableSubject> _currentGalaxies = new List<TableSubject>();
+        private List<TableSubject> _currentGalaxies = new List<TableSubject>();
         public List<TableSubject> CurrentGalaxies
         {
             get => _currentGalaxies;
@@ -28,8 +29,9 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _spaceCutoutUrl, value);
         }
 
-        public SpaceViewModel()
+        public SpaceViewModel(IPanoptesService panoptesService)
         {
+            _panoptesService = panoptesService;
             PrepareForNewPosition();
             Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
         }
@@ -74,12 +76,11 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async Task GetSubjectsAsync()
         {
-            ApiClient client = new ApiClient();
             NameValueCollection query = new NameValueCollection();
             query.Add("workflow_id", Config.WorkflowId);
             query.Add("page_size", "25");
 
-            var GalaxyList = await client.Subjects.GetList("queued", query);
+            var GalaxyList = await _panoptesService.GetSubjectsAsync("queued", query);
             foreach (Subject subject in GalaxyList)
             {
                 TableSubject Galaxy = new TableSubject(subject, RA, DEC);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -31,10 +31,10 @@ namespace GalaxyZooTouchTable.ViewModels
         public SpaceViewModel()
         {
             PrepareForNewPosition();
-            Messenger.Default.Register<ClassificationRingCreator>(this, OnClassificationSent);
+            Messenger.Default.Register<ClassificationRingCreator>(this, OnClassificationBegun);
         }
 
-        private void OnClassificationSent(ClassificationRingCreator RingCreator)
+        private void OnClassificationBegun(ClassificationRingCreator RingCreator)
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -1,4 +1,5 @@
-﻿using GalaxyZooTouchTable.Models;
+﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Models;
 using PanoptesNetClient;
 using PanoptesNetClient.Models;
 using System.Collections.Generic;
@@ -30,6 +31,18 @@ namespace GalaxyZooTouchTable.ViewModels
         public SpaceViewModel()
         {
             PrepareForNewPosition();
+            Messenger.Default.Register<ClassificationRingCreator>(this, OnClassificationSent);
+        }
+
+        private void OnClassificationSent(ClassificationRingCreator RingCreator)
+        {
+            foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
+            {
+                if (RingCreator.Subject == SpaceViewGalaxy.Subject)
+                {
+                    SpaceViewGalaxy.AddRing(RingCreator.User);
+                }
+            }
         }
         
         private void GetSpaceCutout()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
@@ -1,16 +1,22 @@
-﻿namespace GalaxyZooTouchTable.ViewModels
+﻿using GalaxyZooTouchTable.Services;
+using Unity;
+
+namespace GalaxyZooTouchTable.ViewModels
 {
     public class ViewModelLocator
     {
-        private static SpaceViewModel spaceViewModel
-            = new SpaceViewModel();
+        IUnityContainer container = new UnityContainer();
 
+        private static SpaceViewModel _spaceViewModel;
         public static SpaceViewModel SpaceViewModel
         {
-            get
-            {
-                return spaceViewModel;
-            }
+            get => _spaceViewModel;
+        }
+
+        public ViewModelLocator()
+        {
+            container.RegisterType<IPanoptesService, PanoptesService>();
+            _spaceViewModel = container.Resolve<SpaceViewModel>();
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Centerpiece.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Centerpiece.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace GalaxyZooTouchTable
 {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -29,13 +29,12 @@
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
-    
-    <Grid>
-        <Grid.RenderTransform>
-            <TranslateTransform X="{Binding TileOffset}" Y="-28"/>
-        </Grid.RenderTransform>
-        <Border CornerRadius="28"
-                VerticalAlignment="Top"
+
+    <Grid x:Name="TileGrid">
+        <Border x:Name="SubjectImage"
+                CornerRadius="28"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
                 Width="56"
                 Height="56">
             <i:Interaction.Behaviors>
@@ -43,38 +42,40 @@
             </i:Interaction.Behaviors>
             <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
         </Border>
-        <ItemsControl x:Name="RingCollection" ItemsSource="{Binding Submissions}">
+        <ItemsControl x:Name="RingCollection" SizeChanged="RingCollection_SizeChanged" ItemsSource="{Binding Submissions}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Grid VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Border
                         Style="{StaticResource ColoredRing}"
                         BorderBrush="{Binding UserColor}"
                         BorderThickness="3"
-                        CornerRadius="{Binding CornerRadius}"
+                        CornerRadius="100"
                         Width="{Binding Diameter}"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
                         Height="{Binding Diameter}">
-                        <Border.RenderTransform>
-                            <TranslateTransform Y="{Binding YPos}"/>
-                        </Border.RenderTransform>
                     </Border>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <ItemsControl ItemsSource="{Binding Submissions}">
+        <ItemsControl ItemsSource="{Binding Submissions}" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Grid />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Border
-                        Width="{Binding Diameter}"
-                        Height="{Binding Diameter}">
-                        <Border.RenderTransform>
-                            <TranslateTransform Y="{Binding YPos}"/>
-                        </Border.RenderTransform>
-                        <Image Style="{StaticResource UserAvatar}" Width="26" Height="26" Source="{Binding UserAvatar}">
-                            <Image.RenderTransform>
-                                <TranslateTransform X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
-                            </Image.RenderTransform>
-                        </Image>
-                    </Border>
+                    <Image Style="{StaticResource UserAvatar}" Width="26" Height="26" Source="{Binding UserAvatar}">
+                        <Image.RenderTransform>
+                            <TranslateTransform X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
+                        </Image.RenderTransform>
+                    </Image>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -42,7 +42,7 @@
             </i:Interaction.Behaviors>
             <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
         </Border>
-        <ItemsControl x:Name="RingCollection" SizeChanged="RingCollection_SizeChanged" ItemsSource="{Binding Submissions}">
+        <ItemsControl x:Name="RingCollection" SizeChanged="RingCollection_SizeChanged" ItemsSource="{Binding GalaxyRings}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <Grid VerticalAlignment="Top" HorizontalAlignment="Left"/>
@@ -63,7 +63,7 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
-        <ItemsControl ItemsSource="{Binding Submissions}" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <ItemsControl ItemsSource="{Binding GalaxyRings}" HorizontalAlignment="Center" VerticalAlignment="Center">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <Grid />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -7,6 +7,29 @@
              xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="100">
+
+    <UserControl.Resources>
+        <Style x:Key="ColoredRing" TargetType="{x:Type Border}">
+            <Setter Property="Opacity" Value="1"/>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=CurrentlyClassifying}" Value="False">
+                    <Setter Property="Opacity" Value="0.3"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="UserAvatar" TargetType="{x:Type Image}">
+            <Setter Property="Visibility" Value="Visible"/>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=CurrentlyClassifying}" Value="False">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+    
     <Grid>
         <Grid.RenderTransform>
             <TranslateTransform X="{Binding TileOffset}" Y="-28"/>
@@ -26,6 +49,7 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Border
+                        Style="{StaticResource ColoredRing}"
                         BorderBrush="{Binding UserColor}"
                         BorderThickness="3"
                         CornerRadius="{Binding CornerRadius}"
@@ -47,7 +71,7 @@
                         <Border.RenderTransform>
                             <TranslateTransform Y="{Binding YPos}"/>
                         </Border.RenderTransform>
-                        <Image Width="26" Height="26" Source="{Binding UserAvatar}">
+                        <Image Style="{StaticResource UserAvatar}" Width="26" Height="26" Source="{Binding UserAvatar}">
                             <Image.RenderTransform>
                                 <TranslateTransform X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
                             </Image.RenderTransform>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -34,9 +34,7 @@
         <Grid.RenderTransform>
             <TranslateTransform X="{Binding TileOffset}" Y="-28"/>
         </Grid.RenderTransform>
-        <Border BorderBrush="{StaticResource AttentionColor}"
-                BorderThickness="3"
-                CornerRadius="28"
+        <Border CornerRadius="28"
                 VerticalAlignment="Top"
                 Width="56"
                 Height="56">

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -9,23 +9,12 @@
              d:DesignHeight="100" d:DesignWidth="100">
     <Grid>
         <Grid.RenderTransform>
-            <TranslateTransform X="-28" Y="-28"/>
+            <TranslateTransform X="{Binding TileOffset}" Y="-28"/>
         </Grid.RenderTransform>
-        <ItemsControl ItemsSource="{Binding Submissions}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Border
-                        BorderBrush="{Binding ThemeColor}"
-                        BorderThickness="3"
-                        CornerRadius="36"
-                        Width="72"
-                        Height="72"/>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
         <Border BorderBrush="{StaticResource AttentionColor}"
                 BorderThickness="3"
                 CornerRadius="28"
+                VerticalAlignment="Top"
                 Width="56"
                 Height="56">
             <i:Interaction.Behaviors>
@@ -33,5 +22,29 @@
             </i:Interaction.Behaviors>
             <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
         </Border>
+        <ItemsControl x:Name="RingCollection" ItemsSource="{Binding Submissions}">
+            <!--<ItemsControl.RenderTransform>
+                <TranslateTransform X="-28" Y="-28"/>
+            </ItemsControl.RenderTransform>-->
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border
+                        BorderBrush="{Binding UserColor}"
+                        BorderThickness="3"
+                        CornerRadius="{Binding CornerRadius}"
+                        Width="{Binding Diameter}"
+                        Height="{Binding Diameter}">
+                        <Border.RenderTransform>
+                            <TranslateTransform Y="{Binding YPos}"/>
+                        </Border.RenderTransform>
+                        <Image Width="26" Height="26" Source="{Binding UserAvatar}">
+                            <Image.RenderTransform>
+                                <TranslateTransform X="{Binding AvatarX}" Y="-0"/>
+                            </Image.RenderTransform>
+                        </Image>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </Grid>
 </UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -23,9 +23,6 @@
             <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
         </Border>
         <ItemsControl x:Name="RingCollection" ItemsSource="{Binding Submissions}">
-            <!--<ItemsControl.RenderTransform>
-                <TranslateTransform X="-28" Y="-28"/>
-            </ItemsControl.RenderTransform>-->
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Border
@@ -37,9 +34,22 @@
                         <Border.RenderTransform>
                             <TranslateTransform Y="{Binding YPos}"/>
                         </Border.RenderTransform>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <ItemsControl ItemsSource="{Binding Submissions}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border
+                        Width="{Binding Diameter}"
+                        Height="{Binding Diameter}">
+                        <Border.RenderTransform>
+                            <TranslateTransform Y="{Binding YPos}"/>
+                        </Border.RenderTransform>
                         <Image Width="26" Height="26" Source="{Binding UserAvatar}">
                             <Image.RenderTransform>
-                                <TranslateTransform X="{Binding AvatarX}" Y="-0"/>
+                                <TranslateTransform X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
                             </Image.RenderTransform>
                         </Image>
                     </Border>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -1,0 +1,37 @@
+﻿<UserControl x:Class="GalaxyZooTouchTable.Views.GalaxyTileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="100">
+    <Grid>
+        <Grid.RenderTransform>
+            <TranslateTransform X="-28" Y="-28"/>
+        </Grid.RenderTransform>
+        <ItemsControl ItemsSource="{Binding Submissions}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border
+                        BorderBrush="{Binding ThemeColor}"
+                        BorderThickness="3"
+                        CornerRadius="36"
+                        Width="72"
+                        Height="72"/>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <Border BorderBrush="{StaticResource AttentionColor}"
+                BorderThickness="3"
+                CornerRadius="28"
+                Width="56"
+                Height="56">
+            <i:Interaction.Behaviors>
+                <Behaviors:UIElementDragBehavior/>
+            </i:Interaction.Behaviors>
+            <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
+        </Border>
+    </Grid>
+</UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
+﻿using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace GalaxyZooTouchTable.Views
 {
@@ -23,6 +11,17 @@ namespace GalaxyZooTouchTable.Views
         public GalaxyTileView()
         {
             InitializeComponent();
+        }
+
+        private void RingCollection_SizeChanged(object sender, System.Windows.SizeChangedEventArgs e)
+        {
+            var OffsetX = (RingCollection.ActualWidth - SubjectImage.ActualWidth) / 2;
+            var OffsetY = (RingCollection.ActualHeight - SubjectImage.ActualHeight) / 2;
+
+            TranslateTransform Transform = new TranslateTransform();
+            Transform.X = (OffsetX * -1) - 28;
+            Transform.Y = (OffsetY * -1) - 28;
+            TileGrid.RenderTransform = Transform;
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
@@ -13,6 +13,10 @@ namespace GalaxyZooTouchTable.Views
             InitializeComponent();
         }
 
+        /// <summary>
+        /// When a galaxy gain or loses rings, the tile must change position so the center point is always over the 
+        /// subject.
+        /// </summary>
         private void RingCollection_SizeChanged(object sender, System.Windows.SizeChangedEventArgs e)
         {
             var OffsetX = (RingCollection.ActualWidth - SubjectImage.ActualWidth) / 2;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace GalaxyZooTouchTable.Views
+{
+    /// <summary>
+    /// Interaction logic for GalaxyTileView.xaml
+    /// </summary>
+    public partial class GalaxyTileView : UserControl
+    {
+        public GalaxyTileView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -3,9 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:GalaxyZooTouchTable"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
-             xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
+             xmlns:views="clr-namespace:GalaxyZooTouchTable.Views"
              mc:Ignorable="d" 
              Height="432"
              Width="1248"
@@ -43,19 +41,7 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Border BorderBrush="{StaticResource AttentionColor}"
-                            BorderThickness="3"
-                            CornerRadius="28"
-                            Width="56"
-                            Height="56">
-                        <i:Interaction.Behaviors>
-                            <Behaviors:UIElementDragBehavior/>
-                        </i:Interaction.Behaviors>
-                        <Border.RenderTransform>
-                            <TranslateTransform X="-28" Y="-28"/>
-                        </Border.RenderTransform>
-                        <Image Opacity="0.5" Width="30" Height="30" Source="{Binding SubjectLocation}"/>
-                    </Border>
+                    <views:GalaxyTileView/>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
             <ItemsControl.ItemContainerStyle>


### PR DESCRIPTION
Just as the title states, this PR adds rings to subjects users have interacted with. 

Solid rings reflect those users are currently classifying, low opacity rings w/o avatars represent those users have already classified on. 

A design change reflected on this PR. The inner yellow/green ring is _always_ present.

https://projects.invisionapp.com/d/main#/console/15093515/333377931/preview
