### PR TITLE
Fix Two Bugs

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -85,6 +85,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GalaxyZooTouchTable\ViewModels\StillThereViewModel.cs">
+      <Link>StillThereViewModel.cs</Link>
+    </Compile>
     <Compile Include="Extensions\NotifyPropertyChangedExtensions.cs" />
     <Compile Include="Mock\GraphQLServiceMockData.cs" />
     <Compile Include="Mock\PanoptesServiceMockData.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/TapBehavior.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/TapBehavior.cs
@@ -27,7 +27,7 @@ namespace GalaxyZooTouchTable.Behaviors
         /// </summary>
         private void AssociatedObject_TouchUp(object sender, TouchEventArgs e)
         {
-            e.Handled = true;
+            e.Handled = Handle;
             if (IsTouchDown && Command.CanExecute(sender))
             {
                 Command.Execute(CommandParameter);
@@ -38,6 +38,15 @@ namespace GalaxyZooTouchTable.Behaviors
         private void AssociatedObject_TouchDown(object sender, TouchEventArgs e)
         {
             IsTouchDown = true;
+        }
+
+        public static readonly DependencyProperty HandleProperty =
+            DependencyProperty.Register("Handle", typeof(bool), typeof(TapBehavior), new UIPropertyMetadata(true));
+
+        public bool Handle
+        {
+            get { return (bool)GetValue(HandleProperty); }
+            set { SetValue(HandleProperty, value); }
         }
 
         public static readonly DependencyProperty CommandProperty =

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -18,7 +18,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private IGraphQLService _graphQLService;
         private IPanoptesService _panoptesService;
         private string CurrentTaskIndex { get; set; }
-        private DispatcherTimer StillThereTimer { get; set; }
+        private DispatcherTimer StillThereTimer { get; set; } = new DispatcherTimer();
 
         public Classification CurrentClassification { get; set; } = new Classification();
         public Subject CurrentSubject { get; set; }
@@ -151,6 +151,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
             LoadCommands();
             AddSubscribers();
+            SetTimer();
         }
 
         private void AddSubscribers()
@@ -160,7 +161,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Notifications.GetSubjectById += OnGetSubjectById;
             Notifications.ChangeView += OnChangeView;
             Notifications.SendRequestToUser += OnSendRequestToUser;
-            StillThere.ResetFiveMinuteTimer += ResetTimer;
+            StillThere.ResetFiveMinuteTimer += StartTimer;
             StillThere.CloseClassificationPanel += OnCloseClassifier;
         }
 
@@ -232,7 +233,6 @@ namespace GalaxyZooTouchTable.ViewModels
             PrepareForNewClassification();
             Notifications.ClearNotifications(UserIsLeaving);
 
-            StillThereTimer = null;
             ClassifierOpen = false;
             CloseConfirmationVisible = false;
             User.Active = false;
@@ -290,20 +290,24 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
+        private void SetTimer()
+        {
+            StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
+            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
+            StartTimer();
+        }
+
         private void StartTimer()
         {
-            StillThereTimer = new DispatcherTimer();
-            StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            ResetTimer();
+            StillThereTimer.Stop();
+            StillThereTimer.Start();
+            if (StillThere.Visible) { StillThere.Visible = false; }
         }
 
         private void ShowStillThereModal(object sender, System.EventArgs e)
         {
-            if (StillThereTimer != null)
-            {
-                StillThereTimer.Stop();
-                StillThere.Visible = true;
-            }
+            StillThereTimer.Stop();
+            StillThere.Visible = true;
         }
 
         public void ChooseAnswer(AnswerButton button)
@@ -311,19 +315,9 @@ namespace GalaxyZooTouchTable.ViewModels
             CurrentAnnotation = new Annotation(CurrentTaskIndex, button.Index);
         }
 
-        private void ResetTimer()
-        {
-            if (StillThereTimer != null)
-            {
-                StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
-                StillThereTimer.Start();
-            }
-            if (StillThere.Visible) { StillThere.Visible = false; }
-        }
-
         private void ResetTimer(object sender, PropertyChangedEventArgs e)
         {
-            ResetTimer();
+            StartTimer();
         }
 
         public List<AnswerButton> ParseTaskAnswers(List<TaskAnswer> answers)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -156,12 +156,12 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void AddSubscribers()
         {
-            ExamplesViewModel.PropertyChanged += ResetTimer;
-            LevelerViewModel.PropertyChanged += ResetTimer;
+            ExamplesViewModel.PropertyChanged += ResetStillThereModalTimer;
+            LevelerViewModel.PropertyChanged += ResetStillThereModalTimer;
             Notifications.GetSubjectById += OnGetSubjectById;
             Notifications.ChangeView += OnChangeView;
             Notifications.SendRequestToUser += OnSendRequestToUser;
-            StillThere.ResetFiveMinuteTimer += StartTimer;
+            StillThere.ResetFiveMinuteTimer += StartStillThereModalTimer;
             StillThere.CloseClassificationPanel += OnCloseClassifier;
         }
 
@@ -218,7 +218,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnOpenClassifier(object sender)
         {
-            StartTimer();
+            StartStillThereModalTimer();
             ClassifierOpen = true;
             User.Active = true;
             LevelerViewModel = new LevelerViewModel(User);
@@ -294,10 +294,10 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
             StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
-            StartTimer();
+            StartStillThereModalTimer();
         }
 
-        private void StartTimer()
+        public void StartStillThereModalTimer()
         {
             StillThereTimer.Stop();
             StillThereTimer.Start();
@@ -315,9 +315,9 @@ namespace GalaxyZooTouchTable.ViewModels
             CurrentAnnotation = new Annotation(CurrentTaskIndex, button.Index);
         }
 
-        private void ResetTimer(object sender, PropertyChangedEventArgs e)
+        private void ResetStillThereModalTimer(object sender, PropertyChangedEventArgs e)
         {
-            StartTimer();
+            StartStillThereModalTimer();
         }
 
         public List<AnswerButton> ParseTaskAnswers(List<TaskAnswer> answers)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -293,7 +293,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
+            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
             StartStillThereModalTimer();
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -9,8 +9,8 @@ namespace GalaxyZooTouchTable.ViewModels
 {
     public class StillThereViewModel : ViewModelBase
     {
-        public DispatcherTimer SecondTimer { get; set; }
-        public DispatcherTimer ThirtySecondTimer { get; set; }
+        public DispatcherTimer SecondTimer { get; set; } = new DispatcherTimer();
+        public DispatcherTimer ThirtySecondTimer { get; set; } = new DispatcherTimer();
         public event Action<object> CloseClassificationPanel = delegate { };
         public event Action ResetFiveMinuteTimer = delegate { };
         private int Percentage { get; set; } = 100;
@@ -55,6 +55,8 @@ namespace GalaxyZooTouchTable.ViewModels
             LoadCommands();
             Circle.RenderArc(Percentage);
             Circle.PropertyChanged += CircleChanged;
+
+            SetTimers();
         }
 
         private void CircleChanged(object sender, PropertyChangedEventArgs e)
@@ -79,29 +81,32 @@ namespace GalaxyZooTouchTable.ViewModels
             ResetFiveMinuteTimer();
         }
 
+        private void SetTimers()
+        {
+            SecondTimer.Tick += new EventHandler(OneSecondElapsed);
+            SecondTimer.Interval = new TimeSpan(0, 0, 1);
+
+            ThirtySecondTimer.Tick += new EventHandler(ThirtySecondsElapsed);
+            ThirtySecondTimer.Interval = new TimeSpan(0, 0, 31);
+        }
+
         private void StartTimers()
         {
             CurrentSeconds = 30;
             Percentage = 100;
-            SecondTimer = new DispatcherTimer();
-            SecondTimer.Tick += new EventHandler(OneSecondElapsed);
-            SecondTimer.Interval = new TimeSpan(0, 0, 1);
-            SecondTimer.Start();
 
-            ThirtySecondTimer = new DispatcherTimer();
-            ThirtySecondTimer.Tick += new EventHandler(ThirtySecondsElapsed);
-            ThirtySecondTimer.Interval = new TimeSpan(0, 0, 31);
+            SecondTimer.Stop();
+            ThirtySecondTimer.Stop();
+
+            SecondTimer.Start();
             ThirtySecondTimer.Start();
             Circle.RenderArc(Percentage);
         }
 
         private void StopTimers()
         {
-            if (SecondTimer != null && ThirtySecondTimer != null)
-            {
-                SecondTimer.Stop();
-                ThirtySecondTimer.Stop();
-            }
+            SecondTimer.Stop();
+            ThirtySecondTimer.Stop();
         }
 
         private void ThirtySecondsElapsed(object sender, EventArgs e)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -10,7 +10,6 @@ namespace GalaxyZooTouchTable.ViewModels
     public class StillThereViewModel : ViewModelBase
     {
         public DispatcherTimer SecondTimer { get; set; } = new DispatcherTimer();
-        public DispatcherTimer ThirtySecondTimer { get; set; } = new DispatcherTimer();
         public event Action<object> CloseClassificationPanel = delegate { };
         public event Action ResetFiveMinuteTimer = delegate { };
         private int Percentage { get; set; } = 100;
@@ -40,10 +39,10 @@ namespace GalaxyZooTouchTable.ViewModels
             {
                 if (value == true)
                 {
-                    StartTimers();
+                    StartTimer();
                 } else
                 {
-                    StopTimers();
+                    SecondTimer.Stop();
                 }
                 SetProperty(ref _visible, value);
             }
@@ -56,7 +55,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Circle.RenderArc(Percentage);
             Circle.PropertyChanged += CircleChanged;
 
-            SetTimers();
+            SetTimer();
         }
 
         private void CircleChanged(object sender, PropertyChangedEventArgs e)
@@ -81,38 +80,20 @@ namespace GalaxyZooTouchTable.ViewModels
             ResetFiveMinuteTimer();
         }
 
-        private void SetTimers()
+        private void SetTimer()
         {
             SecondTimer.Tick += new EventHandler(OneSecondElapsed);
             SecondTimer.Interval = new TimeSpan(0, 0, 1);
-
-            ThirtySecondTimer.Tick += new EventHandler(ThirtySecondsElapsed);
-            ThirtySecondTimer.Interval = new TimeSpan(0, 0, 31);
         }
 
-        private void StartTimers()
+        private void StartTimer()
         {
             CurrentSeconds = 30;
             Percentage = 100;
 
             SecondTimer.Stop();
-            ThirtySecondTimer.Stop();
-
             SecondTimer.Start();
-            ThirtySecondTimer.Start();
             Circle.RenderArc(Percentage);
-        }
-
-        private void StopTimers()
-        {
-            SecondTimer.Stop();
-            ThirtySecondTimer.Stop();
-        }
-
-        private void ThirtySecondsElapsed(object sender, EventArgs e)
-        {
-            CloseClassificationPanel(sender);
-            Visible = false;
         }
 
         private void OneSecondElapsed(object sender, EventArgs e)
@@ -122,6 +103,12 @@ namespace GalaxyZooTouchTable.ViewModels
             decimal PercentOfSeconds = (CurrentSeconds / StartingSeconds) * 100;
             Percentage = Convert.ToInt16(Math.Floor(PercentOfSeconds));
             Circle.RenderArc(Percentage);
+
+            if (CurrentSeconds == 0)
+            {
+                CloseClassificationPanel(null);
+                Visible = false;
+            }
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -22,7 +22,7 @@
         </DataTemplate>
     </UserControl.Resources>
  
-    <Grid Height="315" Width="547">
+    <Grid Height="315" Width="547" TouchUp="ResetTimer">
         <Views:Leveler
             DataContext="{Binding LevelerViewModel}"
             HorizontalAlignment="Left"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Controls;
+﻿using GalaxyZooTouchTable.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace GalaxyZooTouchTable
 {
@@ -10,6 +12,13 @@ namespace GalaxyZooTouchTable
         public ClassificationPanel()
         {
             InitializeComponent();
+        }
+
+        private void ResetTimer(object sender, System.Windows.Input.TouchEventArgs e)
+        {
+            var Element = sender as FrameworkElement;
+            ClassificationPanelViewModel Classifier = Element.DataContext as ClassificationPanelViewModel;
+            Classifier.StartStillThereModalTimer();
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml
@@ -15,7 +15,7 @@
     <Viewbox HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <local:DragCanvas x:Name="RootCanvas" Background="Black" Width="1920" Height="1080">
             <local:Centerpiece x:Name="Centerpiece" Canvas.Left="333" Canvas.Top="330"/>
-            
+
             <local:UserConsole
                 x:Name="PersonUser"
                 DataContext="{Binding PersonUserVM}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StartButton.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StartButton.xaml
@@ -41,7 +41,7 @@
         BorderThickness="0"
         Style="{StaticResource StartButtonStyle}">
         <i:Interaction.Behaviors>
-            <Behaviors:TapBehavior Command="{Binding OpenClassifier}"/>
+            <Behaviors:TapBehavior Command="{Binding OpenClassifier}" Handle="False"/>
         </i:Interaction.Behaviors>
         <Button.RenderTransform>
             <TranslateTransform Y="{Binding Path=ActualHeight, ElementName=ButtonContainer, Converter={StaticResource HidePanelConverter}, ConverterParameter='1'}"/>


### PR DESCRIPTION
This PR fixes a couple bugs:

- There was a bad bug with the timer, mainly due to my misunderstanding of how `DispatcherTimer` works. You could easily recreate this bug if you opened several windows and toggled the panels to "reset" the timer (however, that reset wasn't working correctly). The timer now also resets whenever a touch is made on the classifier.

- Previously, when you dragged a galaxy over the an unused classifier/start button, the galaxy image would persist. This was due to an error in the `TapBehavior` where underlying elements weren't receiving events.