### PR TITLE
Introduce Local Staging DB

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -49,6 +49,9 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.SQLite, Version=1.0.110.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.110.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.5.9.0-RC\lib\net46\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
@@ -128,6 +131,8 @@
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Extensions\NotifyPropertyChangedExtensions.cs" />
     <Compile Include="Mock\GraphQLServiceMockData.cs" />
     <Compile Include="Mock\PanoptesServiceMockData.cs" />
+    <Compile Include="Mock\SpaceNavigationMockData.cs" />
     <Compile Include="Models\TableSubjectTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\CenterpieceViewModelTests.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
@@ -7,6 +7,8 @@ namespace GalaxyZooTouchTable.Tests.Mock
 {
     public static class PanoptesServiceMockData
     {
+        public static TableSubject TableSubject = new TableSubject("1", "www.fakewebsite.com", 22.22, 33.33);
+
         public static List<TaskAnswer> TaskAnswerList()
         {
             List<TaskAnswer> TaskAnswers = new List<TaskAnswer>();
@@ -58,6 +60,7 @@ namespace GalaxyZooTouchTable.Tests.Mock
                 Id = "1",
                 Locations = mockLocation
             };
+
         }
 
         public static AnswerButton AnswerButton()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
@@ -77,5 +77,12 @@ namespace GalaxyZooTouchTable.Tests.Mock
             subjectList.Add(Subject());
             return subjectList;
         }
+
+        public static List<TableSubject> TableSubjects()
+        {
+            List<TableSubject> subjectList = new List<TableSubject>();
+            subjectList.Add(TableSubject);
+            return subjectList;
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
@@ -7,8 +7,6 @@ namespace GalaxyZooTouchTable.Tests.Mock
 {
     public static class PanoptesServiceMockData
     {
-        public static TableSubject TableSubject = new TableSubject("1", "www.fakewebsite.com", 22.22, 33.33);
-
         public static List<TaskAnswer> TaskAnswerList()
         {
             List<TaskAnswer> TaskAnswers = new List<TaskAnswer>();
@@ -25,6 +23,11 @@ namespace GalaxyZooTouchTable.Tests.Mock
             TaskAnswers.Add(FirstTask);
             TaskAnswers.Add(SecondTask);
             return TaskAnswers;
+        }
+
+        public static TableSubject TableSubject()
+        {
+            return new TableSubject("1", "www.fakewebsite.com", 22.22, 33.33);
         }
 
         public static Workflow Workflow(string id = null)
@@ -81,7 +84,7 @@ namespace GalaxyZooTouchTable.Tests.Mock
         public static List<TableSubject> TableSubjects()
         {
             List<TableSubject> subjectList = new List<TableSubject>();
-            subjectList.Add(TableSubject);
+            subjectList.Add(TableSubject());
             return subjectList;
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
@@ -1,5 +1,4 @@
 ﻿using GalaxyZooTouchTable.Models;
-using Newtonsoft.Json.Linq;
 using PanoptesNetClient.Models;
 using System.Collections.Generic;
 
@@ -52,33 +51,12 @@ namespace GalaxyZooTouchTable.Tests.Mock
             };
         }
 
-        public static Subject Subject()
-        {
-            List<dynamic> mockLocation = new List<dynamic>()
-                {
-                    new JArray()
-                };
-            return new Subject()
-            {
-                Id = "1",
-                Locations = mockLocation
-            };
-
-        }
-
         public static AnswerButton AnswerButton()
         {
             TaskAnswer Answer = new TaskAnswer();
             Answer.Label = "Smooth Galaxy";
             Answer.Next = "T1";
             return new AnswerButton(Answer, 1);
-        }
-
-        public static List<Subject> Subjects()
-        {
-            List<Subject> subjectList = new List<Subject>();
-            subjectList.Add(Subject());
-            return subjectList;
         }
 
         public static List<TableSubject> TableSubjects()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/SpaceNavigationMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/SpaceNavigationMockData.cs
@@ -1,0 +1,17 @@
+﻿using GalaxyZooTouchTable.Models;
+
+namespace GalaxyZooTouchTable.Tests.Mock
+{
+    public static class SpaceNavigationMockData
+    {
+        public static SpacePoint Center()
+        {
+            return new SpacePoint(10, 10);
+        }
+
+        public static SpaceNavigation CurrentLocation()
+        {
+            return new SpaceNavigation(Center());
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Models/TableSubjectTests.cs
@@ -8,13 +8,10 @@ namespace GalaxyZooTouchTable.Tests.Models
 {
     public class TableSubjectTests
     {
-        private TableSubject _tableSubject { get; set; }
+        private TableSubject _tableSubject = PanoptesServiceMockData.TableSubject();
 
         public TableSubjectTests()
         {
-            Subject _subject = PanoptesServiceMockData.Subject();
-            _tableSubject = new TableSubject(_subject, 0, 0);
-
             _tableSubject.GalaxyRings.Add(new GalaxyRing(1, GlobalData.GetInstance().StarUser));
             _tableSubject.GalaxyRings.Add(new GalaxyRing(2, GlobalData.GetInstance().EarthUser));
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -26,10 +26,10 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _panoptesServiceMock.Setup(dp => dp.CreateClassificationAsync(new Classification()))
                 .Returns(Task.CompletedTask);
 
-            _graphQLServiceMock.Setup(dp => dp.GetReductionAsync(new Workflow(), PanoptesServiceMockData.TableSubject))
+            _graphQLServiceMock.Setup(dp => dp.GetReductionAsync(new Workflow(), PanoptesServiceMockData.TableSubject()))
                 .ReturnsAsync(GraphQLServiceMockData.GraphQLResponse());
 
-            _localDBServiceMock.Setup(dp => dp.GetLocalSubject("1")).Returns(PanoptesServiceMockData.TableSubject);
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubject("1")).Returns(PanoptesServiceMockData.TableSubject());
             _localDBServiceMock.Setup(dp => dp.GetQueuedSubjects()).Returns(PanoptesServiceMockData.TableSubjects());
 
             _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _graphQLServiceMock.Object, _localDBServiceMock.Object, new StarUser());
@@ -178,7 +178,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         private async void ShouldCreateANewClassification()
         {
             await _viewModel.GetWorkflow();
-            var Subject = PanoptesServiceMockData.TableSubject;
+            var Subject = PanoptesServiceMockData.TableSubject();
 
             _viewModel.StartNewClassification(Subject);
             Assert.Null(_viewModel.CurrentAnnotation);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -23,22 +23,14 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         {
             _panoptesServiceMock.Setup(dp => dp.GetWorkflowAsync("1"))
                 .ReturnsAsync(PanoptesServiceMockData.Workflow("1"));
-
-            _panoptesServiceMock.Setup(dp => dp.GetSubjectAsync("1"))
-                .ReturnsAsync(PanoptesServiceMockData.Subject());
-
-            NameValueCollection query = new NameValueCollection
-                {
-                    { "workflow_id", "1" }
-                };
-            _panoptesServiceMock.Setup(dp => dp.GetSubjectsAsync("queued", query))
-                .ReturnsAsync(PanoptesServiceMockData.Subjects());
-
             _panoptesServiceMock.Setup(dp => dp.CreateClassificationAsync(new Classification()))
                 .Returns(Task.CompletedTask);
 
             _graphQLServiceMock.Setup(dp => dp.GetReductionAsync(new Workflow(), PanoptesServiceMockData.TableSubject))
                 .ReturnsAsync(GraphQLServiceMockData.GraphQLResponse());
+
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubject("1")).Returns(PanoptesServiceMockData.TableSubject);
+            _localDBServiceMock.Setup(dp => dp.GetQueuedSubjects()).Returns(PanoptesServiceMockData.TableSubjects());
 
             _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _graphQLServiceMock.Object, _localDBServiceMock.Object, new StarUser());
         }
@@ -72,31 +64,31 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         private void ShouldLoadASubject()
         {
             _viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
-            //_viewModel.OnGetSubjectById("1");
-            //_panoptesServiceMock.Verify(vm => vm.GetSubjectAsync("1"), Times.Once);
-            //_graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
-            //Assert.NotNull(_viewModel.CurrentSubject);
+            _viewModel.OnGetSubjectById("1");
+            _localDBServiceMock.Verify(vm => vm.GetLocalSubject("1"), Times.Once);
+            _graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
+            Assert.NotNull(_viewModel.CurrentSubject);
         }
 
         [Fact]
         private void ShouldOpenClassifier()
         {
-            //_viewModel.Load();
-            //_viewModel.OpenClassifier.Execute(null);
-            //Assert.True(_viewModel.ClassifierOpen);
-            //Assert.True(_viewModel.User.Active);
+            _viewModel.Load();
+            _viewModel.OpenClassifier.Execute(null);
+            Assert.True(_viewModel.ClassifierOpen);
+            Assert.True(_viewModel.User.Active);
         }
 
         [Fact]
         private void ShouldCloseClassifier()
         {
-            //_viewModel.Load();
-            //_viewModel.Workflow = PanoptesServiceMockData.Workflow();
-            //_viewModel.CloseClassifier.Execute(null);
+            _viewModel.Load();
+            _viewModel.Workflow = PanoptesServiceMockData.Workflow();
+            _viewModel.CloseClassifier.Execute(null);
 
-            //Assert.False(_viewModel.ClassifierOpen);
-            //Assert.False(_viewModel.CloseConfirmationVisible);
-            //Assert.False(_viewModel.User.Active);
+            Assert.False(_viewModel.ClassifierOpen);
+            Assert.False(_viewModel.CloseConfirmationVisible);
+            Assert.False(_viewModel.User.Active);
         }
 
         [Fact]
@@ -118,47 +110,47 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private void ShouldLoadSubjects()
         {
-            //_viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
-            //_viewModel.GetSubjectQueue();
-            //NameValueCollection query = new NameValueCollection
-            //    {
-            //        { "workflow_id", "1" }
-            //    };
-            //_panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Once);
-            //_graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
-            //Assert.NotNull(_viewModel.CurrentSubject);
+            _viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
+            _viewModel.GetSubjectQueue();
+            NameValueCollection query = new NameValueCollection
+                {
+                    { "workflow_id", "1" }
+                };
+            _localDBServiceMock.Verify(vm => vm.GetQueuedSubjects(), Times.Once);
+            _graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
+            Assert.NotNull(_viewModel.CurrentSubject);
         }
 
         [Fact]
         private void ShouldSubmitClassificationOnSubmission()
         {
-            //_viewModel.Load();
-            //Assert.Empty(_viewModel.CurrentClassification.Annotations);
+            _viewModel.Load();
+            Assert.Empty(_viewModel.CurrentClassification.Annotations);
 
-            //_viewModel.SelectAnswer.Execute(PanoptesServiceMockData.AnswerButton());
-            //_viewModel.ContinueClassification.Execute(null);
-            //_panoptesServiceMock.Verify(vm => vm.CreateClassificationAsync(_viewModel.CurrentClassification), Times.Once);
+            _viewModel.SelectAnswer.Execute(PanoptesServiceMockData.AnswerButton());
+            _viewModel.ContinueClassification.Execute(null);
+            _panoptesServiceMock.Verify(vm => vm.CreateClassificationAsync(_viewModel.CurrentClassification), Times.Once);
 
-            //Assert.Equal(1, _viewModel.SelectedAnswer.AnswerCount);
-            //Assert.Equal(1, _viewModel.TotalVotes);
-            //Assert.Equal(1, _viewModel.ClassificationsThisSession);
-            //Assert.Single(_viewModel.CurrentClassification.Annotations);
+            Assert.Equal(1, _viewModel.SelectedAnswer.AnswerCount);
+            Assert.Equal(1, _viewModel.TotalVotes);
+            Assert.Equal(1, _viewModel.ClassificationsThisSession);
+            Assert.Single(_viewModel.CurrentClassification.Annotations);
         }
 
         [Fact]
         private void ShouldLoadANewSubjectWhenContinuingSummary()
         {
-            //_viewModel.Load();
-            //Assert.Empty(_viewModel.Subjects);
+            _viewModel.Load();
+            Assert.Empty(_viewModel.Subjects);
 
-            //_viewModel.CurrentView = ClassifierViewEnum.SummaryView;
-            //_viewModel.ContinueClassification.Execute(null);
+            _viewModel.CurrentView = ClassifierViewEnum.SummaryView;
+            _viewModel.ContinueClassification.Execute(null);
 
-            //NameValueCollection query = new NameValueCollection
-            //    {
-            //        { "workflow_id", "1" }
-            //    };
-            //_panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Exactly(2));
+            NameValueCollection query = new NameValueCollection
+                {
+                    { "workflow_id", "1" }
+                };
+            _localDBServiceMock.Verify(vm => vm.GetQueuedSubjects(), Times.Exactly(2));
         }
 
         [Fact]
@@ -185,13 +177,13 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private async void ShouldCreateANewClassification()
         {
-            //await _viewModel.GetWorkflow();
-            //var TestSubject = PanoptesServiceMockData.Subject();
+            await _viewModel.GetWorkflow();
+            var Subject = PanoptesServiceMockData.TableSubject;
 
-            //_viewModel.StartNewClassification(TestSubject);
-            //Assert.Null(_viewModel.CurrentAnnotation);
-            //Assert.Null(_viewModel.SelectedAnswer);
-            //Assert.NotNull(_viewModel.CurrentClassification);
+            _viewModel.StartNewClassification(Subject);
+            Assert.Null(_viewModel.CurrentAnnotation);
+            Assert.Null(_viewModel.SelectedAnswer);
+            Assert.NotNull(_viewModel.CurrentClassification);
         }
 
         [Fact]

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -17,6 +17,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         private ClassificationPanelViewModel _viewModel { get; set; }
         private Mock<IPanoptesService> _panoptesServiceMock = new Mock<IPanoptesService>();
         private Mock<IGraphQLService> _graphQLServiceMock = new Mock<IGraphQLService>();
+        private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
 
         public ClassificationPanelViewModelTests()
         {
@@ -36,10 +37,10 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _panoptesServiceMock.Setup(dp => dp.CreateClassificationAsync(new Classification()))
                 .Returns(Task.CompletedTask);
 
-            _graphQLServiceMock.Setup(dp => dp.GetReductionAsync(new Workflow(), new Subject()))
+            _graphQLServiceMock.Setup(dp => dp.GetReductionAsync(new Workflow(), PanoptesServiceMockData.TableSubject))
                 .ReturnsAsync(GraphQLServiceMockData.GraphQLResponse());
 
-            _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _graphQLServiceMock.Object, new StarUser());
+            _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _graphQLServiceMock.Object, _localDBServiceMock.Object, new StarUser());
         }
 
         [Fact]
@@ -71,31 +72,31 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         private void ShouldLoadASubject()
         {
             _viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
-            _viewModel.OnGetSubjectById("1");
-            _panoptesServiceMock.Verify(vm => vm.GetSubjectAsync("1"), Times.Once);
-            _graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
-            Assert.NotNull(_viewModel.CurrentSubject);
+            //_viewModel.OnGetSubjectById("1");
+            //_panoptesServiceMock.Verify(vm => vm.GetSubjectAsync("1"), Times.Once);
+            //_graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
+            //Assert.NotNull(_viewModel.CurrentSubject);
         }
 
         [Fact]
         private void ShouldOpenClassifier()
         {
-            _viewModel.Load();
-            _viewModel.OpenClassifier.Execute(null);
-            Assert.True(_viewModel.ClassifierOpen);
-            Assert.True(_viewModel.User.Active);
+            //_viewModel.Load();
+            //_viewModel.OpenClassifier.Execute(null);
+            //Assert.True(_viewModel.ClassifierOpen);
+            //Assert.True(_viewModel.User.Active);
         }
 
         [Fact]
         private void ShouldCloseClassifier()
         {
-            _viewModel.Load();
-            _viewModel.Workflow = PanoptesServiceMockData.Workflow();
-            _viewModel.CloseClassifier.Execute(null);
+            //_viewModel.Load();
+            //_viewModel.Workflow = PanoptesServiceMockData.Workflow();
+            //_viewModel.CloseClassifier.Execute(null);
 
-            Assert.False(_viewModel.ClassifierOpen);
-            Assert.False(_viewModel.CloseConfirmationVisible);
-            Assert.False(_viewModel.User.Active);
+            //Assert.False(_viewModel.ClassifierOpen);
+            //Assert.False(_viewModel.CloseConfirmationVisible);
+            //Assert.False(_viewModel.User.Active);
         }
 
         [Fact]
@@ -117,47 +118,47 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private void ShouldLoadSubjects()
         {
-            _viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
-            _viewModel.GetSubjectQueue();
-            NameValueCollection query = new NameValueCollection
-                {
-                    { "workflow_id", "1" }
-                };
-            _panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Once);
-            _graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
-            Assert.NotNull(_viewModel.CurrentSubject);
+            //_viewModel.Workflow = PanoptesServiceMockData.Workflow("1");
+            //_viewModel.GetSubjectQueue();
+            //NameValueCollection query = new NameValueCollection
+            //    {
+            //        { "workflow_id", "1" }
+            //    };
+            //_panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Once);
+            //_graphQLServiceMock.Verify(vm => vm.GetReductionAsync(_viewModel.Workflow, _viewModel.CurrentSubject), Times.Once);
+            //Assert.NotNull(_viewModel.CurrentSubject);
         }
 
         [Fact]
         private void ShouldSubmitClassificationOnSubmission()
         {
-            _viewModel.Load();
-            Assert.Empty(_viewModel.CurrentClassification.Annotations);
+            //_viewModel.Load();
+            //Assert.Empty(_viewModel.CurrentClassification.Annotations);
 
-            _viewModel.SelectAnswer.Execute(PanoptesServiceMockData.AnswerButton());
-            _viewModel.ContinueClassification.Execute(null);
-            _panoptesServiceMock.Verify(vm => vm.CreateClassificationAsync(_viewModel.CurrentClassification), Times.Once);
+            //_viewModel.SelectAnswer.Execute(PanoptesServiceMockData.AnswerButton());
+            //_viewModel.ContinueClassification.Execute(null);
+            //_panoptesServiceMock.Verify(vm => vm.CreateClassificationAsync(_viewModel.CurrentClassification), Times.Once);
 
-            Assert.Equal(1, _viewModel.SelectedAnswer.AnswerCount);
-            Assert.Equal(1, _viewModel.TotalVotes);
-            Assert.Equal(1, _viewModel.ClassificationsThisSession);
-            Assert.Single(_viewModel.CurrentClassification.Annotations);
+            //Assert.Equal(1, _viewModel.SelectedAnswer.AnswerCount);
+            //Assert.Equal(1, _viewModel.TotalVotes);
+            //Assert.Equal(1, _viewModel.ClassificationsThisSession);
+            //Assert.Single(_viewModel.CurrentClassification.Annotations);
         }
 
         [Fact]
         private void ShouldLoadANewSubjectWhenContinuingSummary()
         {
-            _viewModel.Load();
-            Assert.Empty(_viewModel.Subjects);
+            //_viewModel.Load();
+            //Assert.Empty(_viewModel.Subjects);
 
-            _viewModel.CurrentView = ClassifierViewEnum.SummaryView;
-            _viewModel.ContinueClassification.Execute(null);
+            //_viewModel.CurrentView = ClassifierViewEnum.SummaryView;
+            //_viewModel.ContinueClassification.Execute(null);
 
-            NameValueCollection query = new NameValueCollection
-                {
-                    { "workflow_id", "1" }
-                };
-            _panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Exactly(2));
+            //NameValueCollection query = new NameValueCollection
+            //    {
+            //        { "workflow_id", "1" }
+            //    };
+            //_panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", query), Times.Exactly(2));
         }
 
         [Fact]
@@ -184,17 +185,17 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private async void ShouldCreateANewClassification()
         {
-            await _viewModel.GetWorkflow();
-            var TestSubject = PanoptesServiceMockData.Subject();
+            //await _viewModel.GetWorkflow();
+            //var TestSubject = PanoptesServiceMockData.Subject();
 
-            _viewModel.StartNewClassification(TestSubject);
-            Assert.Null(_viewModel.CurrentAnnotation);
-            Assert.Null(_viewModel.SelectedAnswer);
-            Assert.NotNull(_viewModel.CurrentClassification);
+            //_viewModel.StartNewClassification(TestSubject);
+            //Assert.Null(_viewModel.CurrentAnnotation);
+            //Assert.Null(_viewModel.SelectedAnswer);
+            //Assert.NotNull(_viewModel.CurrentClassification);
         }
 
         [Fact]
-        private void ShouldTheResetAnswerCount()
+        private void ShouldResetAnswerCount()
         {
             List<TaskAnswer> Answers = PanoptesServiceMockData.TaskAnswerList();
             _viewModel.CurrentAnswers = _viewModel.ParseTaskAnswers(Answers);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -3,7 +3,7 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Tests.Mock;
 using GalaxyZooTouchTable.ViewModels;
 using Moq;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using Xunit;
 
 namespace GalaxyZooTouchTable.Tests.ViewModels
@@ -11,18 +11,10 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
     public class SpaceViewModelTests
     {
         private SpaceViewModel _viewModel { get; set; }
-        private Mock<IPanoptesService> _panoptesServiceMock = new Mock<IPanoptesService>();
         private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
-        private NameValueCollection _query;
 
         public SpaceViewModelTests()
         {
-            _query = new NameValueCollection
-                {
-                    { "workflow_id", "1" },
-                    { "page_size", "25" }
-                };
-
             _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(new SpacePoint());
             _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(
                 It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
@@ -37,9 +29,66 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             Assert.NotNull(_viewModel);
             Assert.NotNull(_viewModel.CurrentGalaxies);
             Assert.NotNull(_viewModel.SpaceCutoutUrl);
+            Assert.False(_viewModel.ShowError);
             _localDBServiceMock.Verify(vm => vm.GetRandomPoint(), Times.Once);
             _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(
                 It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()), Times.Once);
+        }
+
+        public class EmptyResultsAtNextTile
+        {
+            private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
+            private SpaceViewModel _viewModel { get; set; }
+
+            public EmptyResultsAtNextTile()
+            {
+                _localDBServiceMock.Setup(dp => dp.FindNextAscendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,10));
+                _localDBServiceMock.Setup(dp => dp.FindNextDescendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,-10));
+                _localDBServiceMock.Setup(dp => dp.FindNextAscendingRa(It.IsAny<double>())).Returns(new SpacePoint(10,0));
+                _localDBServiceMock.Setup(dp => dp.FindNextDescendingRa(It.IsAny<double>())).Returns(new SpacePoint(-10,0));
+                _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(new SpacePoint());
+                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(
+                    It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
+                    .Returns(new List<TableSubject>());
+
+                _viewModel = new SpaceViewModel(_localDBServiceMock.Object);
+            }
+
+            [Fact]
+            private void ShouldMoveUp()
+            {
+                double OldDec = SpaceNavigation.DEC;
+                _viewModel.MoveViewNorth.Execute(null);
+                Assert.True(OldDec < SpaceNavigation.DEC);
+                _localDBServiceMock.Verify(vm => vm.FindNextAscendingDec(It.IsAny<double>()), Times.Once);
+            }
+
+            [Fact]
+            private void ShouldMoveRight()
+            {
+                double OldRa = SpaceNavigation.RA;
+                _viewModel.MoveViewEast.Execute(null);
+                Assert.True(OldRa > SpaceNavigation.RA);
+                _localDBServiceMock.Verify(vm => vm.FindNextDescendingRa(It.IsAny<double>()), Times.Once);
+            }
+
+            [Fact]
+            private void ShouldMoveDown()
+            {
+                double OldDec = SpaceNavigation.DEC;
+                _viewModel.MoveViewSouth.Execute(null);
+                Assert.True(OldDec > SpaceNavigation.DEC);
+                _localDBServiceMock.Verify(vm => vm.FindNextDescendingDec(It.IsAny<double>()), Times.Once);
+            }
+
+            [Fact]
+            private void ShouldMoveLeft()
+            {
+                double Ra = SpaceNavigation.RA;
+                _viewModel.MoveViewWest.Execute(null);
+                Assert.True(Ra < SpaceNavigation.RA);
+                _localDBServiceMock.Verify(vm => vm.FindNextAscendingRa(It.IsAny<double>()), Times.Once);
+            }
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -15,9 +15,8 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
 
         public SpaceViewModelTests()
         {
-            _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(new SpacePoint());
-            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(
-                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
+            _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(SpaceNavigationMockData.Center());
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>()))
                 .Returns(PanoptesServiceMockData.TableSubjects());
 
             _viewModel = new SpaceViewModel(_localDBServiceMock.Object);
@@ -31,24 +30,23 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             Assert.NotNull(_viewModel.SpaceCutoutUrl);
             Assert.False(_viewModel.ShowError);
             _localDBServiceMock.Verify(vm => vm.GetRandomPoint(), Times.Once);
-            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(
-                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()), Times.Once);
+            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(It.IsAny<SpaceNavigation>()), Times.Once);
         }
 
         public class EmptyResultsAtNextTile
         {
             private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
             private SpaceViewModel _viewModel { get; set; }
+            SpaceNavigation CurrentLocation { get; set; } = SpaceNavigationMockData.CurrentLocation();
 
             public EmptyResultsAtNextTile()
             {
-                _localDBServiceMock.Setup(dp => dp.FindNextAscendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,10));
-                _localDBServiceMock.Setup(dp => dp.FindNextDescendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,-10));
-                _localDBServiceMock.Setup(dp => dp.FindNextAscendingRa(It.IsAny<double>())).Returns(new SpacePoint(10,0));
-                _localDBServiceMock.Setup(dp => dp.FindNextDescendingRa(It.IsAny<double>())).Returns(new SpacePoint(-10,0));
-                _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(new SpacePoint());
-                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(
-                    It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
+                _localDBServiceMock.Setup(dp => dp.FindNextAscendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,20));
+                _localDBServiceMock.Setup(dp => dp.FindNextDescendingDec(It.IsAny<double>())).Returns(new SpacePoint(0,-20));
+                _localDBServiceMock.Setup(dp => dp.FindNextAscendingRa(It.IsAny<double>())).Returns(new SpacePoint(20,0));
+                _localDBServiceMock.Setup(dp => dp.FindNextDescendingRa(It.IsAny<double>())).Returns(new SpacePoint(-20,0));
+                _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(SpaceNavigationMockData.Center());
+                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>()))
                     .Returns(new List<TableSubject>());
 
                 _viewModel = new SpaceViewModel(_localDBServiceMock.Object);
@@ -57,36 +55,36 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             [Fact]
             private void ShouldMoveUp()
             {
-                double OldDec = SpaceNavigation.DEC;
+                double OldDec = _viewModel.CurrentLocation.Center.Declination;
                 _viewModel.MoveViewNorth.Execute(null);
-                Assert.True(OldDec < SpaceNavigation.DEC);
+                Assert.True(OldDec < _viewModel.CurrentLocation.Center.Declination);
                 _localDBServiceMock.Verify(vm => vm.FindNextAscendingDec(It.IsAny<double>()), Times.Once);
             }
 
             [Fact]
             private void ShouldMoveRight()
             {
-                double OldRa = SpaceNavigation.RA;
+                double OldRa = _viewModel.CurrentLocation.Center.RightAscension;
                 _viewModel.MoveViewEast.Execute(null);
-                Assert.True(OldRa > SpaceNavigation.RA);
+                Assert.True(OldRa > _viewModel.CurrentLocation.Center.RightAscension);
                 _localDBServiceMock.Verify(vm => vm.FindNextDescendingRa(It.IsAny<double>()), Times.Once);
             }
 
             [Fact]
             private void ShouldMoveDown()
             {
-                double OldDec = SpaceNavigation.DEC;
+                double OldDec = _viewModel.CurrentLocation.Center.Declination;
                 _viewModel.MoveViewSouth.Execute(null);
-                Assert.True(OldDec > SpaceNavigation.DEC);
+                Assert.True(OldDec > _viewModel.CurrentLocation.Center.Declination);
                 _localDBServiceMock.Verify(vm => vm.FindNextDescendingDec(It.IsAny<double>()), Times.Once);
             }
 
             [Fact]
             private void ShouldMoveLeft()
             {
-                double Ra = SpaceNavigation.RA;
+                double OldRa = _viewModel.CurrentLocation.Center.RightAscension;
                 _viewModel.MoveViewWest.Execute(null);
-                Assert.True(Ra < SpaceNavigation.RA);
+                Assert.True(OldRa < _viewModel.CurrentLocation.Center.RightAscension);
                 _localDBServiceMock.Verify(vm => vm.FindNextAscendingRa(It.IsAny<double>()), Times.Once);
             }
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -1,4 +1,6 @@
-﻿using GalaxyZooTouchTable.Services;
+﻿using GalaxyZooTouchTable.Models;
+using GalaxyZooTouchTable.Services;
+using GalaxyZooTouchTable.Tests.Mock;
 using GalaxyZooTouchTable.ViewModels;
 using Moq;
 using System.Collections.Specialized;
@@ -10,6 +12,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
     {
         private SpaceViewModel _viewModel { get; set; }
         private Mock<IPanoptesService> _panoptesServiceMock = new Mock<IPanoptesService>();
+        private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
         private NameValueCollection _query;
 
         public SpaceViewModelTests()
@@ -20,15 +23,23 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
                     { "page_size", "25" }
                 };
 
-            _viewModel = new SpaceViewModel(_panoptesServiceMock.Object);
+            _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(new SpacePoint());
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(
+                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()))
+                .Returns(PanoptesServiceMockData.TableSubjects());
+
+            _viewModel = new SpaceViewModel(_localDBServiceMock.Object);
         }
 
         [Fact]
         private void ShouldInitializeWithDefaultValues()
         {
+            Assert.NotNull(_viewModel);
             Assert.NotNull(_viewModel.CurrentGalaxies);
             Assert.NotNull(_viewModel.SpaceCutoutUrl);
-            _panoptesServiceMock.Verify(vm => vm.GetSubjectsAsync("queued", _query), Times.Once);
+            _localDBServiceMock.Verify(vm => vm.GetRandomPoint(), Times.Once);
+            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(
+                It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>()), Times.Once);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/app.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/app.config
@@ -13,6 +13,14 @@
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SQLitePCLRaw.provider.e_sqlite3" publicKeyToken="9c301db686d0bd12" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/packages.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
   <package id="Moq" version="4.10.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
+  <package id="System.Data.SQLite.Core" version="1.0.110.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.Debug.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.Debug.config
@@ -9,5 +9,6 @@
     <add key="WorkflowId" value="3251"  xdt:Transform="Replace" xdt:Locator="Match(key)" />
     <add key="ProjectId" value="1857"  xdt:Transform="Replace" xdt:Locator="Match(key)" />
     <add key="CaesarHost" value="https://caesar-staging.zooniverse.org/graphql" xdt:Transform="Replace" xdt:Locator="Match(key)" />
+    <add key="DatabaseName" value="GZ_Staging_Subjects.db" xdt:Transform="Replace" xdt:Locator="Match(key)" />
   </appSettings>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.Release.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.Release.config
@@ -9,5 +9,6 @@
     <add key="WorkflowId" value="6122"  xdt:Transform="Replace" xdt:Locator="Match(key)" />
     <add key="ProjectId" value="5733"  xdt:Transform="Replace" xdt:Locator="Match(key)" />
     <add key="CaesarHost" value="https://caesar.zooniverse.org/graphql" xdt:Transform="Replace" xdt:Locator="Match(key)" />
+    <add key="DatabaseName" value="GZ_Production_Subjects.db" xdt:Transform="Replace" xdt:Locator="Match(key)" />
   </appSettings>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
   <appSettings>
     <add key="Environment" value="Debug" />
     <add key="ApiHost" value="https://panoptes-staging.zooniverse.org" />
@@ -9,9 +13,9 @@
     <add key="StatsHost" value="https://stats.zooniverse.org" />
     <add key="CaesarHost" value="https://caesar-staging.zooniverse.org/graphql" />
   </appSettings>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -22,6 +26,27 @@
         <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="94bc3704cddfc263" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SQLitePCLRaw.provider.e_sqlite3" publicKeyToken="9c301db686d0bd12" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+    </providers>
+  </entityFramework>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+  </system.data>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
@@ -12,6 +12,7 @@
     <add key="ProjectId" value="1857" />
     <add key="StatsHost" value="https://stats.zooniverse.org" />
     <add key="CaesarHost" value="https://caesar-staging.zooniverse.org/graphql" />
+    <add key="DatabaseName" value="GZ_Staging_Subjects.db" />
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -9,7 +9,7 @@ namespace GalaxyZooTouchTable
     /// </summary>
     public partial class App : Application
     {
-        static string databaseName = "GZ_Staging_Subjectsl.db";
+        static string databaseName = "GZ_Staging_Subjects.db";
         static string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         public static string DatabasePath = System.IO.Path.Combine(folderPath, databaseName);
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using GalaxyZooTouchTable.ViewModels;
+using System;
 using System.Windows;
 
 namespace GalaxyZooTouchTable
@@ -8,6 +9,10 @@ namespace GalaxyZooTouchTable
     /// </summary>
     public partial class App : Application
     {
+        static string databaseName = "test_database.db";
+        static string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        public static string databasePath = System.IO.Path.Combine(folderPath, databaseName);
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -11,7 +11,7 @@ namespace GalaxyZooTouchTable
     {
         static string databaseName = "test_database.db";
         static string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        public static string databasePath = System.IO.Path.Combine(folderPath, databaseName);
+        public static string DatabasePath = System.IO.Path.Combine(folderPath, databaseName);
 
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -9,7 +9,7 @@ namespace GalaxyZooTouchTable
     /// </summary>
     public partial class App : Application
     {
-        static string databaseName = "test_database.db";
+        static string databaseName = "GZ_Staging_Subjectsl.db";
         static string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         public static string DatabasePath = System.IO.Path.Combine(folderPath, databaseName);
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -9,9 +9,8 @@ namespace GalaxyZooTouchTable
     /// </summary>
     public partial class App : Application
     {
-        static string databaseName = "GZ_Staging_Subjects.db";
         static string folderPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        public static string DatabasePath = System.IO.Path.Combine(folderPath, databaseName);
+        public static string DatabasePath = System.IO.Path.Combine(folderPath, Config.DatabaseName);
 
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Config.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Config.cs
@@ -8,6 +8,7 @@ namespace GalaxyZooTouchTable
         public static string WorkflowId;
         public static string ProjectId;
         public static string CaesarHost;
+        public static string DatabaseName;
 
         static Config()
         {
@@ -15,6 +16,7 @@ namespace GalaxyZooTouchTable
             WorkflowId = appSettings["WorkflowId"];
             ProjectId = appSettings["ProjectId"];
             CaesarHost = appSettings["CaesarHost"];
+            DatabaseName = appSettings["DatabaseName"];
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -74,6 +74,12 @@
     <ApplicationIcon>zooniverse_icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
       <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
     </Reference>
@@ -92,12 +98,31 @@
     <Reference Include="PanoptesNetClient, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PanoptesNetClient.1.1.1\lib\net461\PanoptesNetClient.dll</HintPath>
     </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.13.388, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.13\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core, Version=1.1.13.388, Culture=neutral, PublicKeyToken=1488e028ca7ab535, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.core.1.1.13\lib\net45\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.provider.e_sqlite3, Version=1.1.13.388, Culture=neutral, PublicKeyToken=9c301db686d0bd12, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.13\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.ConfigurationManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Configuration.ConfigurationManager.4.4.1\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.110.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.110.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.110.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.110.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.110.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.110.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.WebSockets, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.WebSockets.4.3.0\lib\net46\System.Net.WebSockets.dll</HintPath>
@@ -477,5 +502,13 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
+  <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.13\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.110.0\build\net46\System.Data.SQLite.Core.targets')" />
 </Project>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Lib\SubjectViewEnum.cs" />
     <Compile Include="Models\NotificationRequest.cs" />
     <Compile Include="Models\SpaceNavigation.cs" />
+    <Compile Include="Models\SpacePoint.cs" />
     <Compile Include="Services\GraphQLService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
     <Compile Include="Services\ILocalDBService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -219,7 +219,9 @@
     <Compile Include="Models\NotificationRequest.cs" />
     <Compile Include="Services\GraphQLService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
+    <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />
+    <Compile Include="Services\LocalDBService.cs" />
     <Compile Include="Services\PanoptesService.cs" />
     <Compile Include="ViewModels\CenterpieceViewModel.cs" />
     <Compile Include="ViewModels\NotificationsViewModel.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Models\IClassificationPanelViewModelFactory.cs" />
     <Compile Include="Lib\SubjectViewEnum.cs" />
     <Compile Include="Models\NotificationRequest.cs" />
+    <Compile Include="Models\SpaceNavigation.cs" />
     <Compile Include="Services\GraphQLService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -219,7 +219,6 @@
     <Compile Include="Models\NotificationRequest.cs" />
     <Compile Include="Services\GraphQLService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
-    <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />
     <Compile Include="Services\LocalDBService.cs" />
     <Compile Include="Services\PanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Models\SpaceNavigation.cs" />
     <Compile Include="Services\GraphQLService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
+    <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />
     <Compile Include="Services\LocalDBService.cs" />
     <Compile Include="Services\PanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/ContainerHelper.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/ContainerHelper.cs
@@ -16,6 +16,9 @@ namespace GalaxyZooTouchTable.Lib
             _container.RegisterType<IGraphQLService, GraphQLService>(
                 new ContainerControlledLifetimeManager());
 
+            _container.RegisterType<ILocalDBService, LocalDBService>(
+                new ContainerControlledLifetimeManager());
+
             _container.RegisterType<IClassificationPanelViewModelFactory, ClassificationPanelViewModelFactory>(
                 new ContainerControlledLifetimeManager());
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
@@ -8,39 +8,38 @@ namespace GalaxyZooTouchTable.Models
     public class ClassificationPanelViewModelFactory : IClassificationPanelViewModelFactory
     {
         private ILocalDBService _localDBService;
-        private IGraphQLService _graphQLRepo;
-        private IPanoptesService _panoptesRepo;
+        private IGraphQLService _graphQLService;
+        private IPanoptesService _panoptesService;
 
-        public ClassificationPanelViewModelFactory(IPanoptesService panoptesRepo, IGraphQLService graphQLRepo, ILocalDBService localDBService)
+        public ClassificationPanelViewModelFactory(IPanoptesService panoptesService, IGraphQLService graphQLService, ILocalDBService localDBService)
         {
-            if (panoptesRepo == null || graphQLRepo == null || localDBService == null)
+            if (panoptesService == null || graphQLService == null || localDBService == null)
             {
                 throw new ArgumentNullException("RepoDependency");
             }
 
             _localDBService = localDBService;
-            _graphQLRepo = graphQLRepo; 
-            _panoptesRepo = panoptesRepo;
+            _graphQLService = graphQLService; 
+            _panoptesService = panoptesService;
         }
 
         public ClassificationPanelViewModel Create(UserType type)
         {
+            TableUser User = AssignUser(type);
+            return new ClassificationPanelViewModel(_panoptesService, _graphQLService, _localDBService, User);
+        }
+
+        private TableUser AssignUser(UserType type)
+        {
             switch (type)
             {
-                case UserType.Person:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().PersonUser);
-                case UserType.Star:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().StarUser);
-                case UserType.Earth:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().EarthUser);
-                case UserType.Light:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().LightUser);
-                case UserType.Face:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().FaceUser);
-                case UserType.Heart:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().HeartUser);
-                default:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().HeartUser);
+                case UserType.Person: return GlobalData.GetInstance().PersonUser;
+                case UserType.Star: return GlobalData.GetInstance().StarUser;
+                case UserType.Earth: return GlobalData.GetInstance().EarthUser;
+                case UserType.Light: return GlobalData.GetInstance().LightUser;
+                case UserType.Face: return GlobalData.GetInstance().FaceUser;
+                case UserType.Heart: return GlobalData.GetInstance().HeartUser;
+                default: return GlobalData.GetInstance().HeartUser;
             }
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
@@ -7,18 +7,20 @@ namespace GalaxyZooTouchTable.Models
 {
     public class ClassificationPanelViewModelFactory : IClassificationPanelViewModelFactory
     {
-        private IPanoptesService _panoptesRepo;
+        private ILocalDBService _localDBService;
         private IGraphQLService _graphQLRepo;
+        private IPanoptesService _panoptesRepo;
 
-        public ClassificationPanelViewModelFactory(IPanoptesService panoptesRepo, IGraphQLService graphQLRepo)
+        public ClassificationPanelViewModelFactory(IPanoptesService panoptesRepo, IGraphQLService graphQLRepo, ILocalDBService localDBService)
         {
-            if (panoptesRepo == null || graphQLRepo == null)
+            if (panoptesRepo == null || graphQLRepo == null || localDBService == null)
             {
                 throw new ArgumentNullException("RepoDependency");
             }
 
+            _localDBService = localDBService;
+            _graphQLRepo = graphQLRepo; 
             _panoptesRepo = panoptesRepo;
-            _graphQLRepo = graphQLRepo;
         }
 
         public ClassificationPanelViewModel Create(UserType type)
@@ -26,19 +28,19 @@ namespace GalaxyZooTouchTable.Models
             switch (type)
             {
                 case UserType.Person:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().PersonUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().PersonUser);
                 case UserType.Star:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().StarUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().StarUser);
                 case UserType.Earth:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().EarthUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().EarthUser);
                 case UserType.Light:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().LightUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().LightUser);
                 case UserType.Face:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().FaceUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().FaceUser);
                 case UserType.Heart:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().HeartUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().HeartUser);
                 default:
-                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, GlobalData.GetInstance().HeartUser);
+                    return new ClassificationPanelViewModel(_panoptesRepo, _graphQLRepo, _localDBService, GlobalData.GetInstance().HeartUser);
             }
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationRingNotifier.cs
@@ -9,7 +9,7 @@ namespace GalaxyZooTouchTable.Models
         public string SubjectId { get; private set; }
         public RingNotifierStatus Status { get; set; }
 
-        public ClassificationRingNotifier(Subject subject, TableUser user, RingNotifierStatus status)
+        public ClassificationRingNotifier(TableSubject subject, TableUser user, RingNotifierStatus status)
         {
             SubjectId = subject != null ? subject.Id : null;
             Status = status;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -6,16 +6,4 @@
         public static double DEC { get; set; }
         public static double PlateScale { get; set; } = 1.5;
     }
-
-    public class SpacePoint
-    {
-        public double RightAscension { get; set; }
-        public double Declination { get; set; }
-
-        public SpacePoint(double ra = 0, double dec = 0)
-        {
-            RightAscension = ra;
-            Declination = dec;
-        }
-    }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -12,7 +12,7 @@
         public double RightAscension { get; set; }
         public double Declination { get; set; }
 
-        public SpacePoint(double ra, double dec)
+        public SpacePoint(double ra = 0, double dec = 0)
         {
             RightAscension = ra;
             Declination = dec;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -1,9 +1,74 @@
 ﻿namespace GalaxyZooTouchTable.Models
 {
-    public static class SpaceNavigation
+    public class SpaceNavigation
     {
-        public static double RA { get; set; }
-        public static double DEC { get; set; }
-        public static double PlateScale { get; set; } = 1.5;
+        public const double PlateScale = 1.5;
+        const int CutoutWidth = 1248;
+        const int CutoutHeight = 432;
+        const int ArcDegreeInSeconds = 3600;
+        public double DecRange { get; set; } = CutoutHeight * PlateScale / ArcDegreeInSeconds;
+        public double MinRa { get; set; }
+        public double MaxRa { get; set; }
+        public double MinDec { get; set; }
+        public double MaxDec { get; set; }
+
+        private SpacePoint _center;
+        public SpacePoint Center
+        {
+            get => _center;
+            set
+            {
+                _center = value;
+                UpdateBounds();
+            }
+        }
+
+        public SpaceNavigation(SpacePoint center)
+        {
+            Center = center;
+            UpdateBounds();
+        }
+
+        public double RaRange()
+        {
+            return (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(Center.Declination))));
+        }
+
+        private void UpdateBounds()
+        {
+            MinRa = Center.RightAscension - (RaRange() / 2);
+            MaxRa = Center.RightAscension + (RaRange() / 2);
+            MinDec = Center.Declination - (DecRange / 2);
+            MaxDec = Center.Declination + (DecRange / 2);
+        }
+
+        private double ToRadians(double Degrees)
+        {
+            return (Degrees * System.Math.PI) / 180.0;
+        }
+
+        public void MoveNorth()
+        {
+            Center.Declination += DecRange;
+            UpdateBounds();
+        }
+
+        public void MoveSouth()
+        {
+            Center.Declination -= DecRange;
+            UpdateBounds();
+        }
+
+        public void MoveEast()
+        {
+            Center.RightAscension -= RaRange();
+            UpdateBounds();
+        }
+
+        public void MoveWest()
+        {
+            Center.RightAscension += RaRange();
+            UpdateBounds();
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -1,0 +1,21 @@
+﻿namespace GalaxyZooTouchTable.Models
+{
+    public static class SpaceNavigation
+    {
+        public static double RA { get; set; }
+        public static double DEC { get; set; }
+        public static double PlateScale { get; set; } = 1.5;
+    }
+
+    public class SpacePoint
+    {
+        public double RightAscension { get; set; }
+        public double Declination { get; set; }
+
+        public SpacePoint(double ra, double dec)
+        {
+            RightAscension = ra;
+            Declination = dec;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpacePoint.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpacePoint.cs
@@ -5,7 +5,7 @@
         public double RightAscension { get; set; }
         public double Declination { get; set; }
 
-        public SpacePoint(double ra = 0, double dec = 0)
+        public SpacePoint(double ra, double dec)
         {
             RightAscension = ra;
             Declination = dec;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpacePoint.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpacePoint.cs
@@ -1,0 +1,14 @@
+﻿namespace GalaxyZooTouchTable.Models
+{
+    public class SpacePoint
+    {
+        public double RightAscension { get; set; }
+        public double Declination { get; set; }
+
+        public SpacePoint(double ra = 0, double dec = 0)
+        {
+            RightAscension = ra;
+            Declination = dec;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -38,20 +38,20 @@ namespace GalaxyZooTouchTable.Models
             RightAscension = ra;
             Declination = dec;
             SubjectLocation = location;
-            XYConvert(257.9, 23.23);
+            XYConvert();
         }
 
-        private void XYConvert(double CenterRightAscension, double CenterDeclination)
+        private void XYConvert()
         {
             int CutoutWidth = 1248; 
             int CutoutHeight = 432;
             const int ArcDegreeInSeconds = 3600;
 
             double DecRange = CutoutHeight * PlateScale / ArcDegreeInSeconds;
-            double RaRange = System.Math.Abs(CutoutWidth * PlateScale / ArcDegreeInSeconds / System.Math.Cos(CenterDeclination));
+            double RaRange = System.Math.Abs(CutoutWidth * PlateScale / ArcDegreeInSeconds / System.Math.Cos(SpaceNavigation.DEC));
 
-            double StartY = ((CenterDeclination - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
-            double StartX = ((CenterRightAscension - RightAscension) / (RaRange + Offset) * CutoutWidth) + (CutoutWidth / 2);
+            double StartY = ((SpaceNavigation.DEC - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
+            double StartX = ((SpaceNavigation.RA - RightAscension) / (RaRange + Offset) * CutoutWidth) + (CutoutWidth / 2);
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -37,6 +37,8 @@ namespace GalaxyZooTouchTable.Models
             Location = location;
             RightAscension = ra;
             Declination = dec;
+            SubjectLocation = location;
+            XYConvert(257.9, 23.23);
         }
 
         private void XYConvert(double CenterRightAscension, double CenterDeclination)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -10,7 +10,7 @@ namespace GalaxyZooTouchTable.Models
         public double RightAscension { get; set; }
         public double Declination { get; set; }
         public string SubjectLocation { get; set; }
-        private readonly double PlateScale = 1.8;
+        private readonly double WidenedPlateScale = 1.8;
         public Subject Subject { get; set; }
         public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
         public string Location { get; set; }
@@ -34,8 +34,8 @@ namespace GalaxyZooTouchTable.Models
             int CutoutHeight = 432;
             const int ArcDegreeInSeconds = 3600;
 
-            double DecRange = CutoutHeight * PlateScale / ArcDegreeInSeconds;
-            double RaRange = (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
+            double DecRange = CutoutHeight * WidenedPlateScale / ArcDegreeInSeconds;
+            double RaRange = (CutoutWidth * WidenedPlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
 
             double StartY = ((SpaceNavigation.DEC - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
             double StartX = System.Math.Abs(((SpaceNavigation.RA - RightAscension) / RaRange * CutoutWidth) + (CutoutWidth / 2));

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -16,22 +16,10 @@ namespace GalaxyZooTouchTable.Models
         public string Location { get; set; }
         public string Id { get; set; }
 
-        public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
-        {
-            if (subject.Metadata != null)
-            {
-                RightAscension = System.Convert.ToDouble(subject.Metadata.ra);
-                Declination = System.Convert.ToDouble(subject.Metadata.dec);
-            }
-            Subject = subject;
-            SubjectLocation = subject.GetSubjectLocation();
-            XYConvert(TableRA, TableDEC);
-
-            GalaxyRings.Add(new GalaxyRing());
-        }
-
         public TableSubject(string id, string location, double ra, double dec)
         {
+            GalaxyRings.Add(new GalaxyRing());
+
             Id = id;
             Location = location;
             RightAscension = ra;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -48,10 +48,10 @@ namespace GalaxyZooTouchTable.Models
             const int ArcDegreeInSeconds = 3600;
 
             double DecRange = CutoutHeight * PlateScale / ArcDegreeInSeconds;
-            double RaRange = System.Math.Abs(CutoutWidth * PlateScale / ArcDegreeInSeconds / System.Math.Cos(SpaceNavigation.DEC));
+            double RaRange = (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
 
             double StartY = ((SpaceNavigation.DEC - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
-            double StartX = ((SpaceNavigation.RA - RightAscension) / (RaRange + Offset) * CutoutWidth) + (CutoutWidth / 2);
+            double StartX = ((SpaceNavigation.RA - RightAscension) / (RaRange) * CutoutWidth) + (CutoutWidth / 2);
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -14,6 +14,8 @@ namespace GalaxyZooTouchTable.Models
         private readonly double Offset = 0.03;
         public Subject Subject { get; set; }
         public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
+        public string Location { get; set; }
+        public string Id { get; set; }
 
         public TableSubject(Subject subject, double TableRA = 0, double TableDEC = 0)
         {
@@ -27,6 +29,14 @@ namespace GalaxyZooTouchTable.Models
             XYConvert(TableRA, TableDEC);
 
             GalaxyRings.Add(new GalaxyRing());
+        }
+
+        public TableSubject(string id, string location, double ra, double dec)
+        {
+            Id = id;
+            Location = location;
+            RightAscension = ra;
+            Declination = dec;
         }
 
         private void XYConvert(double CenterRightAscension, double CenterDeclination)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -10,8 +10,7 @@ namespace GalaxyZooTouchTable.Models
         public double RightAscension { get; set; }
         public double Declination { get; set; }
         public string SubjectLocation { get; set; }
-        private readonly double PlateScale = 1.5;
-        private readonly double Offset = 0.03;
+        private readonly double PlateScale = 1.8;
         public Subject Subject { get; set; }
         public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
         public string Location { get; set; }
@@ -51,7 +50,7 @@ namespace GalaxyZooTouchTable.Models
             double RaRange = (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
 
             double StartY = ((SpaceNavigation.DEC - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
-            double StartX = ((SpaceNavigation.RA - RightAscension) / (RaRange) * CutoutWidth) + (CutoutWidth / 2);
+            double StartX = System.Math.Abs(((SpaceNavigation.RA - RightAscension) / RaRange * CutoutWidth) + (CutoutWidth / 2));
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -5,19 +5,21 @@ namespace GalaxyZooTouchTable.Models
 {
     public class TableSubject
     {
+        SpaceNavigation CurrentLocation { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
         public double RightAscension { get; set; }
         public double Declination { get; set; }
         public string SubjectLocation { get; set; }
-        private readonly double WidenedPlateScale = 1.8;
+        private readonly double WidenedPlateScale = 1.75;
         public Subject Subject { get; set; }
         public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
         public string Location { get; set; }
         public string Id { get; set; }
 
-        public TableSubject(string id, string location, double ra, double dec)
+        public TableSubject(string id, string location, double ra, double dec, SpaceNavigation currentLocation = null)
         {
+            CurrentLocation = currentLocation;
             GalaxyRings.Add(new GalaxyRing());
 
             Id = id;
@@ -25,7 +27,7 @@ namespace GalaxyZooTouchTable.Models
             RightAscension = ra;
             Declination = dec;
             SubjectLocation = location;
-            XYConvert();
+            if (currentLocation != null) XYConvert();
         }
 
         private void XYConvert()
@@ -35,10 +37,10 @@ namespace GalaxyZooTouchTable.Models
             const int ArcDegreeInSeconds = 3600;
 
             double DecRange = CutoutHeight * WidenedPlateScale / ArcDegreeInSeconds;
-            double RaRange = (CutoutWidth * WidenedPlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
+            double RaRange = (CutoutWidth * WidenedPlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos(ToRadians(CurrentLocation.Center.Declination)));
 
-            double StartY = ((SpaceNavigation.DEC - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
-            double StartX = System.Math.Abs(((SpaceNavigation.RA - RightAscension) / RaRange * CutoutWidth) + (CutoutWidth / 2));
+            double StartY = ((CurrentLocation.Center.Declination - Declination) / DecRange * CutoutHeight) + (CutoutHeight / 2);
+            double StartX = System.Math.Abs(((CurrentLocation.Center.RightAscension - RightAscension) / RaRange * CutoutWidth) + (CutoutWidth / 2));
 
             Y = System.Convert.ToInt32(StartY);
             X = System.Convert.ToInt32(StartX);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/GraphQLService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/GraphQLService.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.Client.Http;
+﻿using GalaxyZooTouchTable.Models;
+using GraphQL.Client.Http;
 using GraphQL.Common.Request;
 using GraphQL.Common.Response;
 using PanoptesNetClient.Models;
@@ -10,7 +11,7 @@ namespace GalaxyZooTouchTable.Services
     {
         private GraphQLHttpClient GraphQLClient = new GraphQLHttpClient(Config.CaesarHost);
 
-        public async Task<GraphQLResponse> GetReductionAsync(Workflow workflow, Subject currentSubject)
+        public async Task<GraphQLResponse> GetReductionAsync(Workflow workflow, TableSubject currentSubject)
         {
             GraphQLResponse response = new GraphQLResponse();
             var answersRequest = new GraphQLRequest

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/IGraphQLService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/IGraphQLService.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.Common.Response;
+﻿using GalaxyZooTouchTable.Models;
+using GraphQL.Common.Response;
 using PanoptesNetClient.Models;
 using System.Threading.Tasks;
 
@@ -6,6 +7,6 @@ namespace GalaxyZooTouchTable.Services
 {
     public interface IGraphQLService
     {
-        Task<GraphQLResponse> GetReductionAsync(Workflow workflow, Subject currentSubject);
+        Task<GraphQLResponse> GetReductionAsync(Workflow workflow, TableSubject currentSubject);
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -1,0 +1,21 @@
+﻿using GalaxyZooTouchTable.Models;
+using System.Collections.Generic;
+
+namespace GalaxyZooTouchTable.Services
+{
+    public interface ILocalDBService
+    {
+        TableSubject GetLocalSubject(string id);
+
+        List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90);
+        List<TableSubject> GetQueuedSubjects();
+        List<TableSubject> GetSubjects(string query);
+
+        SpacePoint FindNextAscendingRa(double RaLowerBounds);
+        SpacePoint FindNextDescendingRa(double RaUpperBounds);
+        SpacePoint FindNextAscendingDec(double DecLowerBounds);
+        SpacePoint FindNextDescendingDec(double DecUpperBounds);
+        SpacePoint GetPoint(string query);
+        SpacePoint GetRandomPoint();
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -11,10 +11,10 @@ namespace GalaxyZooTouchTable.Services
         List<TableSubject> GetQueuedSubjects();
         List<TableSubject> GetSubjects(string query);
 
-        SpacePoint FindNextAscendingRa(double RaLowerBounds);
-        SpacePoint FindNextDescendingRa(double RaUpperBounds);
-        SpacePoint FindNextAscendingDec(double DecLowerBounds);
-        SpacePoint FindNextDescendingDec(double DecUpperBounds);
+        SpacePoint FindNextAscendingRa(double raLowerBounds);
+        SpacePoint FindNextDescendingRa(double raUpperBounds);
+        SpacePoint FindNextAscendingDec(double decLowerBounds);
+        SpacePoint FindNextDescendingDec(double decUpperBounds);
         SpacePoint GetPoint(string query);
         SpacePoint GetRandomPoint();
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -7,9 +7,9 @@ namespace GalaxyZooTouchTable.Services
     {
         TableSubject GetLocalSubject(string id);
 
-        List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90);
+        List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation);
         List<TableSubject> GetQueuedSubjects();
-        List<TableSubject> GetSubjects(string query);
+        List<TableSubject> GetSubjects(string query, SpaceNavigation currentLocation = null);
 
         SpacePoint FindNextAscendingRa(double raLowerBounds);
         SpacePoint FindNextDescendingRa(double raUpperBounds);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -125,7 +125,7 @@ namespace GalaxyZooTouchTable.Services
 
         public SpacePoint GetRandomPoint()
         {
-            return GetPoint(RandomSubjectQuery);
+            return GetPoint(RandomSubjectQuery) ?? new SpacePoint(0,0);
         }
 
         public SpacePoint FindNextAscendingRa(double bounds)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -1,0 +1,34 @@
+﻿using GalaxyZooTouchTable.Models;
+using System.Collections.Generic;
+using System.Data.SQLite;
+
+namespace GalaxyZooTouchTable.Services
+{
+    public static class LocalDBService
+    {
+        public static List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subject where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                List<TableSubject> SubjectsWithinBounds = new List<TableSubject>();
+
+                while (reader.Read())
+                {
+                    string id = reader["subject_id"] as string;
+                    string image = reader["image"] as string;
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    TableSubject subjectFromDatabase = new TableSubject(id, image, ra, dec);
+                    SubjectsWithinBounds.Add(subjectFromDatabase);
+                }
+
+                connection.Close();
+                return SubjectsWithinBounds;
+            }
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -100,5 +100,93 @@ namespace GalaxyZooTouchTable.Services
                 return point;
             }
         }
+
+        public static SpacePoint FindNextAscendingRa(double RaLowerBounds)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects where ra > {RaLowerBounds} limit 1";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                SpacePoint point = null;
+
+                while (reader.Read())
+                {
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    point = new SpacePoint(ra, dec);
+                }
+
+                connection.Close();
+                return point;
+            }
+        }
+
+        public static SpacePoint FindNextDescendingRa(double RaUpperBounds)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects where ra < {RaUpperBounds} limit 1";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                SpacePoint point = null;
+
+                while (reader.Read())
+                {
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    point = new SpacePoint(ra, dec);
+                }
+
+                connection.Close();
+                return point;
+            }
+        }
+
+        public static SpacePoint FindNextAscendingDec(double DecLowerBounds)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects where dec > {DecLowerBounds} limit 1";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                SpacePoint point = null;
+
+                while (reader.Read())
+                {
+                    double dec = (double)reader["dec"];
+                    double ra = (double)reader["ra"];
+                    point = new SpacePoint(ra, dec);
+                }
+
+                connection.Close();
+                return point;
+            }
+        }
+
+        public static SpacePoint FindNextDescendingDec(double DecUpperBounds)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects where dec < {DecUpperBounds} limit 1";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                SpacePoint point = null;
+
+                while (reader.Read())
+                {
+                    double dec = (double)reader["dec"];
+                    double ra = (double)reader["ra"];
+                    point = new SpacePoint(ra, dec);
+                }
+
+                connection.Close();
+                return point;
+            }
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -11,7 +11,7 @@ namespace GalaxyZooTouchTable.Services
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
                 connection.Open();
-                string query = $"select * from Subject where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+                string query = $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
                 SQLiteCommand command = new SQLiteCommand(query, connection);
                 SQLiteDataReader reader = command.ExecuteReader();
                 List<TableSubject> SubjectsWithinBounds = new List<TableSubject>();
@@ -28,6 +28,54 @@ namespace GalaxyZooTouchTable.Services
 
                 connection.Close();
                 return SubjectsWithinBounds;
+            }
+        }
+
+        public static TableSubject GetLocalSubject(string id)
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects where subject_id = {id}";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                TableSubject RetrievedSubject = null;
+
+                while (reader.Read())
+                {
+                    string image = reader["image"] as string;
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    RetrievedSubject = new TableSubject(id, image, ra, dec);
+                }
+
+                connection.Close();
+                return RetrievedSubject;
+            }
+        }
+
+        public static List<TableSubject> GetQueuedSubjects()
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects order by classifications_count asc limit 10";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                List<TableSubject> Subjects = new List<TableSubject>();
+
+                while (reader.Read())
+                {
+                    string id = reader["subject_id"] as string;
+                    string image = reader["image"] as string;
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec);
+                    Subjects.Add(RetrievedSubject);
+                }
+
+                connection.Close();
+                return Subjects;
             }
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -78,5 +78,27 @@ namespace GalaxyZooTouchTable.Services
                 return Subjects;
             }
         }
+
+        public static SpacePoint GetRandomPoint()
+        {
+            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            {
+                connection.Open();
+                string query = $"select * from Subjects order by random() limit 1";
+                SQLiteCommand command = new SQLiteCommand(query, connection);
+                SQLiteDataReader reader = command.ExecuteReader();
+                SpacePoint point = null;
+
+                while (reader.Read())
+                {
+                    double ra = (double)reader["ra"];
+                    double dec = (double)reader["dec"];
+                    point = new SpacePoint(ra, dec);
+                }
+
+                connection.Close();
+                return point;
+            }
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -122,53 +122,25 @@ namespace GalaxyZooTouchTable.Services
         public SpacePoint FindNextAscendingRa(double RaLowerBounds)
         {
             string query = $"select * from Subjects where ra > {RaLowerBounds} order by ra asc limit 1";
-            SpacePoint Center = GetPoint(query);
-
-            if (Center == null)
-            {
-                Center = GetPoint(LowestRaQuery);
-            }
-
-            return Center;
+            return GetPoint(query) ?? GetPoint(LowestRaQuery);
         }
 
         public SpacePoint FindNextDescendingRa(double RaUpperBounds)
         {
             string query = $"select * from Subjects where ra < {RaUpperBounds} order by ra desc limit 1";
-            SpacePoint Center = GetPoint(query);
-
-            if (Center == null)
-            {
-                Center = GetPoint(HighestRaQuery);
-            }
-
-            return Center;
+            return GetPoint(query) ?? GetPoint(HighestRaQuery);
         }
 
         public SpacePoint FindNextAscendingDec(double DecLowerBounds)
         {
             string query = $"select * from Subjects where dec > {DecLowerBounds} order by dec asc limit 1";
-            SpacePoint Center = GetPoint(query);
-
-            if (Center == null)
-            {
-                Center = GetPoint(LowestDecQuery);
-            }
-
-            return Center;
+            return GetPoint(query) ?? GetPoint(LowestDecQuery);
         }
 
         public SpacePoint FindNextDescendingDec(double DecUpperBounds)
         {
             string query = $"select * from Subjects where dec < {DecUpperBounds} order by dec desc limit 1";
-            SpacePoint Center = GetPoint(query);
-
-            if (Center == null)
-            {
-                Center = GetPoint(HighestDecQuery);
-            }
-
-            return Center;
+            return GetPoint(query) ?? GetPoint(HighestDecQuery);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -15,21 +15,27 @@ namespace GalaxyZooTouchTable.Services
         {
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
-                connection.Open();
-                string query = $"select * from Subjects where subject_id = {id}";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
                 TableSubject RetrievedSubject = null;
-
-                while (reader.Read())
+                try
                 {
-                    string image = reader["image"] as string;
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    RetrievedSubject = new TableSubject(id, image, ra, dec);
-                }
+                    connection.Open();
+                    string query = $"select * from Subjects where subject_id = {id}";
+                    SQLiteCommand command = new SQLiteCommand(query, connection);
+                    SQLiteDataReader reader = command.ExecuteReader();
 
-                connection.Close();
+                    while (reader.Read())
+                    {
+                        string image = reader["image"] as string;
+                        double ra = (double)reader["ra"];
+                        double dec = (double)reader["dec"];
+                        RetrievedSubject = new TableSubject(id, image, ra, dec);
+                    }
+
+                    connection.Close();
+                } catch (SQLiteException exception)
+                {
+                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                }
                 return RetrievedSubject;
             }
         }
@@ -50,22 +56,28 @@ namespace GalaxyZooTouchTable.Services
         {
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
-                connection.Open();
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
                 List<TableSubject> Subjects = new List<TableSubject>();
-
-                while (reader.Read())
+                try
                 {
-                    string id = reader["subject_id"] as string;
-                    string image = reader["image"] as string;
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec);
-                    Subjects.Add(RetrievedSubject);
-                }
+                    connection.Open();
+                    SQLiteCommand command = new SQLiteCommand(query, connection);
+                    SQLiteDataReader reader = command.ExecuteReader();
 
-                connection.Close();
+                    while (reader.Read())
+                    {
+                        string id = reader["subject_id"] as string;
+                        string image = reader["image"] as string;
+                        double ra = (double)reader["ra"];
+                        double dec = (double)reader["dec"];
+                        TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec);
+                        Subjects.Add(RetrievedSubject);
+                    }
+
+                    connection.Close();
+                } catch (SQLiteException exception)
+                {
+                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                }
                 return Subjects;
             }
         }
@@ -74,19 +86,25 @@ namespace GalaxyZooTouchTable.Services
         {
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
-                connection.Open();
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                SpacePoint point = null;
-
-                while (reader.Read())
+                SpacePoint point = new SpacePoint();
+                try
                 {
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    point = new SpacePoint(ra, dec);
-                }
+                    connection.Open();
+                    SQLiteCommand command = new SQLiteCommand(query, connection);
+                    SQLiteDataReader reader = command.ExecuteReader();
 
-                connection.Close();
+                    while (reader.Read())
+                    {
+                        double ra = (double)reader["ra"];
+                        double dec = (double)reader["dec"];
+                        point = new SpacePoint(ra, dec);
+                    }
+
+                    connection.Close();
+                } catch (SQLiteException exception)
+                {
+                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                }
                 return point;
             }
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -4,14 +4,14 @@ using System.Data.SQLite;
 
 namespace GalaxyZooTouchTable.Services
 {
-    public static class LocalDBService
+    public class LocalDBService : ILocalDBService
     {
-        private static string HighestRaQuery = "select * from Subjects order by ra desc limit 1";
-        private static string HighestDecQuery = "select * from Subjects order by dec desc limit 1";
-        private static string LowestRaQuery = "select * from Subjects order by ra asc limit 1";
-        private static string LowestDecQuery = "select * from Subjects order by dec asc limit 1";
+        string HighestRaQuery = "select * from Subjects order by ra desc limit 1";
+        string HighestDecQuery = "select * from Subjects order by dec desc limit 1";
+        string LowestRaQuery = "select * from Subjects order by ra asc limit 1";
+        string LowestDecQuery = "select * from Subjects order by dec asc limit 1";
 
-        public static TableSubject GetLocalSubject(string id)
+        public TableSubject GetLocalSubject(string id)
         {
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
@@ -34,19 +34,19 @@ namespace GalaxyZooTouchTable.Services
             }
         }
 
-        public static List<TableSubject> GetQueuedSubjects()
+        public List<TableSubject> GetQueuedSubjects()
         {
             string query = "select * from Subjects order by classifications_count asc limit 10";
             return GetSubjects(query);
         }
 
-        public static List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
+        public List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
         {
             string query = $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
             return GetSubjects(query);
         }
 
-        public static List<TableSubject> GetSubjects(string query)
+        public List<TableSubject> GetSubjects(string query)
         {
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
@@ -70,7 +70,7 @@ namespace GalaxyZooTouchTable.Services
             }
         }
 
-        public static SpacePoint GetPoint(string query)
+        public SpacePoint GetPoint(string query)
         {
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
@@ -91,15 +91,15 @@ namespace GalaxyZooTouchTable.Services
             }
         }
 
-        public static SpacePoint GetRandomPoint()
+        public SpacePoint GetRandomPoint()
         {
             string query = "select * from Subjects order by random() limit 1";
             return GetPoint(query);
         }
 
-        public static SpacePoint FindNextAscendingRa(double RaLowerBounds)
+        public SpacePoint FindNextAscendingRa(double RaLowerBounds)
         {
-            string query = $"select * from Subjects where ra > {RaLowerBounds} limit 1";
+            string query = $"select * from Subjects where ra > {RaLowerBounds} order by ra asc limit 1";
             SpacePoint Center = GetPoint(query);
 
             if (Center == null)
@@ -110,9 +110,9 @@ namespace GalaxyZooTouchTable.Services
             return Center;
         }
 
-        public static SpacePoint FindNextDescendingRa(double RaUpperBounds)
+        public SpacePoint FindNextDescendingRa(double RaUpperBounds)
         {
-            string query = $"select * from Subjects where ra < {RaUpperBounds} limit 1";
+            string query = $"select * from Subjects where ra < {RaUpperBounds} order by ra desc limit 1";
             SpacePoint Center = GetPoint(query);
 
             if (Center == null)
@@ -123,9 +123,9 @@ namespace GalaxyZooTouchTable.Services
             return Center;
         }
 
-        public static SpacePoint FindNextAscendingDec(double DecLowerBounds)
+        public SpacePoint FindNextAscendingDec(double DecLowerBounds)
         {
-            string query = $"select * from Subjects where dec > {DecLowerBounds} limit 1";
+            string query = $"select * from Subjects where dec > {DecLowerBounds} order by dec asc limit 1";
             SpacePoint Center = GetPoint(query);
 
             if (Center == null)
@@ -136,9 +136,9 @@ namespace GalaxyZooTouchTable.Services
             return Center;
         }
 
-        public static SpacePoint FindNextDescendingDec(double DecUpperBounds)
+        public SpacePoint FindNextDescendingDec(double DecUpperBounds)
         {
-            string query = $"select * from Subjects where dec < {DecUpperBounds} limit 1";
+            string query = $"select * from Subjects where dec < {DecUpperBounds} order by dec desc limit 1";
             SpacePoint Center = GetPoint(query);
 
             if (Center == null)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -13,7 +13,7 @@ namespace GalaxyZooTouchTable.Services
 
         public TableSubject GetLocalSubject(string id)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
                 connection.Open();
                 string query = $"select * from Subjects where subject_id = {id}";
@@ -48,7 +48,7 @@ namespace GalaxyZooTouchTable.Services
 
         public List<TableSubject> GetSubjects(string query)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
                 connection.Open();
                 SQLiteCommand command = new SQLiteCommand(query, connection);
@@ -72,7 +72,7 @@ namespace GalaxyZooTouchTable.Services
 
         public SpacePoint GetPoint(string query)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
                 connection.Open();
                 SQLiteCommand command = new SQLiteCommand(query, connection);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -1,4 +1,5 @@
-﻿using GalaxyZooTouchTable.Models;
+﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Models;
 using System.Collections.Generic;
 using System.Data.SQLite;
 
@@ -34,7 +35,8 @@ namespace GalaxyZooTouchTable.Services
                     connection.Close();
                 } catch (SQLiteException exception)
                 {
-                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                    string ErrorMessage = $"Error Connecting to Database. Error: {exception.Message}";
+                    Messenger.Default.Send(ErrorMessage, "DatabaseError");
                 }
                 return RetrievedSubject;
             }
@@ -76,7 +78,8 @@ namespace GalaxyZooTouchTable.Services
                     connection.Close();
                 } catch (SQLiteException exception)
                 {
-                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                    string ErrorMessage = $"Error Connecting to Database. Error: {exception.Message}";
+                    Messenger.Default.Send(ErrorMessage, "DatabaseError");
                 }
                 return Subjects;
             }
@@ -103,7 +106,8 @@ namespace GalaxyZooTouchTable.Services
                     connection.Close();
                 } catch (SQLiteException exception)
                 {
-                    System.Console.WriteLine($"Error Connecting to Database. Error Code: {exception.ErrorCode}");
+                    string ErrorMessage = $"Error Connecting to Database. Error: {exception.Message}";
+                    Messenger.Default.Send(ErrorMessage, "DatabaseError");
                 }
                 return point;
             }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -19,9 +19,9 @@ namespace GalaxyZooTouchTable.Services
         string NextAscendingDecQuery(double bounds) { return $"select * from Subjects where dec > {bounds} order by dec asc limit 1"; }
         string NextDescendingDecQuery(double bounds) { return $"select * from Subjects where dec < {bounds} order by dec desc limit 1"; }
 
-        string SubjectsWithinBoundsQuery(double minRa, double minDec, double maxRa, double maxDec)
+        string SubjectsWithinBoundsQuery(SpaceNavigation location)
         {
-            return $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+            return $"select * from Subjects where dec > {location.MinDec} and dec < {location.MaxDec} and ra > {location.MinRa} and ra < {location.MaxRa}";
         }
 
         public TableSubject GetLocalSubject(string id)
@@ -58,13 +58,13 @@ namespace GalaxyZooTouchTable.Services
             return GetSubjects(QueuedSubjectsQuery);
         }
 
-        public List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
+        public List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation)
         {
-            string query = SubjectsWithinBoundsQuery(minRa, minDec, maxRa, maxDec);
-            return GetSubjects(query);
+            string query = SubjectsWithinBoundsQuery(currentLocation);
+            return GetSubjects(query, currentLocation);
         }
 
-        public List<TableSubject> GetSubjects(string query)
+        public List<TableSubject> GetSubjects(string query, SpaceNavigation currentLocation = null)
         {
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
@@ -81,7 +81,7 @@ namespace GalaxyZooTouchTable.Services
                         string image = reader["image"] as string;
                         double ra = (double)reader["ra"];
                         double dec = (double)reader["dec"];
-                        TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec);
+                        TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec, currentLocation);
                         Subjects.Add(RetrievedSubject);
                     }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -99,7 +99,7 @@ namespace GalaxyZooTouchTable.Services
         {
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
             {
-                SpacePoint point = new SpacePoint();
+                SpacePoint point = null;
                 try
                 {
                     connection.Open();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -6,30 +6,10 @@ namespace GalaxyZooTouchTable.Services
 {
     public static class LocalDBService
     {
-        public static List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
-        {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
-            {
-                connection.Open();
-                string query = $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                List<TableSubject> SubjectsWithinBounds = new List<TableSubject>();
-
-                while (reader.Read())
-                {
-                    string id = reader["subject_id"] as string;
-                    string image = reader["image"] as string;
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    TableSubject subjectFromDatabase = new TableSubject(id, image, ra, dec);
-                    SubjectsWithinBounds.Add(subjectFromDatabase);
-                }
-
-                connection.Close();
-                return SubjectsWithinBounds;
-            }
-        }
+        private static string HighestRaQuery = "select * from Subjects order by ra desc limit 1";
+        private static string HighestDecQuery = "select * from Subjects order by dec desc limit 1";
+        private static string LowestRaQuery = "select * from Subjects order by ra asc limit 1";
+        private static string LowestDecQuery = "select * from Subjects order by dec asc limit 1";
 
         public static TableSubject GetLocalSubject(string id)
         {
@@ -56,10 +36,21 @@ namespace GalaxyZooTouchTable.Services
 
         public static List<TableSubject> GetQueuedSubjects()
         {
+            string query = "select * from Subjects order by classifications_count asc limit 10";
+            return GetSubjects(query);
+        }
+
+        public static List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
+        {
+            string query = $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+            return GetSubjects(query);
+        }
+
+        public static List<TableSubject> GetSubjects(string query)
+        {
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
                 connection.Open();
-                string query = $"select * from Subjects order by classifications_count asc limit 10";
                 SQLiteCommand command = new SQLiteCommand(query, connection);
                 SQLiteDataReader reader = command.ExecuteReader();
                 List<TableSubject> Subjects = new List<TableSubject>();
@@ -79,12 +70,11 @@ namespace GalaxyZooTouchTable.Services
             }
         }
 
-        public static SpacePoint GetRandomPoint()
+        public static SpacePoint GetPoint(string query)
         {
             using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
             {
                 connection.Open();
-                string query = $"select * from Subjects order by random() limit 1";
                 SQLiteCommand command = new SQLiteCommand(query, connection);
                 SQLiteDataReader reader = command.ExecuteReader();
                 SpacePoint point = null;
@@ -99,94 +89,64 @@ namespace GalaxyZooTouchTable.Services
                 connection.Close();
                 return point;
             }
+        }
+
+        public static SpacePoint GetRandomPoint()
+        {
+            string query = "select * from Subjects order by random() limit 1";
+            return GetPoint(query);
         }
 
         public static SpacePoint FindNextAscendingRa(double RaLowerBounds)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            string query = $"select * from Subjects where ra > {RaLowerBounds} limit 1";
+            SpacePoint Center = GetPoint(query);
+
+            if (Center == null)
             {
-                connection.Open();
-                string query = $"select * from Subjects where ra > {RaLowerBounds} limit 1";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                SpacePoint point = null;
-
-                while (reader.Read())
-                {
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    point = new SpacePoint(ra, dec);
-                }
-
-                connection.Close();
-                return point;
+                Center = GetPoint(LowestRaQuery);
             }
+
+            return Center;
         }
 
         public static SpacePoint FindNextDescendingRa(double RaUpperBounds)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            string query = $"select * from Subjects where ra < {RaUpperBounds} limit 1";
+            SpacePoint Center = GetPoint(query);
+
+            if (Center == null)
             {
-                connection.Open();
-                string query = $"select * from Subjects where ra < {RaUpperBounds} limit 1";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                SpacePoint point = null;
-
-                while (reader.Read())
-                {
-                    double ra = (double)reader["ra"];
-                    double dec = (double)reader["dec"];
-                    point = new SpacePoint(ra, dec);
-                }
-
-                connection.Close();
-                return point;
+                Center = GetPoint(HighestRaQuery);
             }
+
+            return Center;
         }
 
         public static SpacePoint FindNextAscendingDec(double DecLowerBounds)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            string query = $"select * from Subjects where dec > {DecLowerBounds} limit 1";
+            SpacePoint Center = GetPoint(query);
+
+            if (Center == null)
             {
-                connection.Open();
-                string query = $"select * from Subjects where dec > {DecLowerBounds} limit 1";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                SpacePoint point = null;
-
-                while (reader.Read())
-                {
-                    double dec = (double)reader["dec"];
-                    double ra = (double)reader["ra"];
-                    point = new SpacePoint(ra, dec);
-                }
-
-                connection.Close();
-                return point;
+                Center = GetPoint(LowestDecQuery);
             }
+
+            return Center;
         }
 
         public static SpacePoint FindNextDescendingDec(double DecUpperBounds)
         {
-            using (SQLiteConnection connection = new SQLiteConnection("Data Source=C:\\sqlite\\databases\\test_database.db"))
+            string query = $"select * from Subjects where dec < {DecUpperBounds} limit 1";
+            SpacePoint Center = GetPoint(query);
+
+            if (Center == null)
             {
-                connection.Open();
-                string query = $"select * from Subjects where dec < {DecUpperBounds} limit 1";
-                SQLiteCommand command = new SQLiteCommand(query, connection);
-                SQLiteDataReader reader = command.ExecuteReader();
-                SpacePoint point = null;
-
-                while (reader.Read())
-                {
-                    double dec = (double)reader["dec"];
-                    double ra = (double)reader["ra"];
-                    point = new SpacePoint(ra, dec);
-                }
-
-                connection.Close();
-                return point;
+                Center = GetPoint(HighestDecQuery);
             }
+
+            return Center;
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -11,6 +11,18 @@ namespace GalaxyZooTouchTable.Services
         string HighestDecQuery = "select * from Subjects order by dec desc limit 1";
         string LowestRaQuery = "select * from Subjects order by ra asc limit 1";
         string LowestDecQuery = "select * from Subjects order by dec asc limit 1";
+        string QueuedSubjectsQuery = "select * from Subjects order by classifications_count asc limit 10";
+        string RandomSubjectQuery = "select * from Subjects order by random() limit 1";
+        string SubjectByIdQuery(string id) { return $"select * from Subjects where subject_id = {id}"; }
+        string NextAscendingRaQuery(double bounds) { return $"select * from Subjects where ra > {bounds} order by ra asc limit 1"; }
+        string NextDescendingRaQuery(double bounds) { return $"select * from Subjects where ra < {bounds} order by ra desc limit 1"; }
+        string NextAscendingDecQuery(double bounds) { return $"select * from Subjects where dec > {bounds} order by dec asc limit 1"; }
+        string NextDescendingDecQuery(double bounds) { return $"select * from Subjects where dec < {bounds} order by dec desc limit 1"; }
+
+        string SubjectsWithinBoundsQuery(double minRa, double minDec, double maxRa, double maxDec)
+        {
+            return $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+        }
 
         public TableSubject GetLocalSubject(string id)
         {
@@ -20,8 +32,7 @@ namespace GalaxyZooTouchTable.Services
                 try
                 {
                     connection.Open();
-                    string query = $"select * from Subjects where subject_id = {id}";
-                    SQLiteCommand command = new SQLiteCommand(query, connection);
+                    SQLiteCommand command = new SQLiteCommand(SubjectByIdQuery(id), connection);
                     SQLiteDataReader reader = command.ExecuteReader();
 
                     while (reader.Read())
@@ -44,13 +55,12 @@ namespace GalaxyZooTouchTable.Services
 
         public List<TableSubject> GetQueuedSubjects()
         {
-            string query = "select * from Subjects order by classifications_count asc limit 10";
-            return GetSubjects(query);
+            return GetSubjects(QueuedSubjectsQuery);
         }
 
         public List<TableSubject> GetLocalSubjects(double minRa = 0, double maxRa = 360, double minDec = -90, double maxDec = 90)
         {
-            string query = $"select * from Subjects where dec > {minDec} and dec < {maxDec} and ra > {minRa} and ra < {maxRa}";
+            string query = SubjectsWithinBoundsQuery(minRa, minDec, maxRa, maxDec);
             return GetSubjects(query);
         }
 
@@ -115,32 +125,27 @@ namespace GalaxyZooTouchTable.Services
 
         public SpacePoint GetRandomPoint()
         {
-            string query = "select * from Subjects order by random() limit 1";
-            return GetPoint(query);
+            return GetPoint(RandomSubjectQuery);
         }
 
-        public SpacePoint FindNextAscendingRa(double RaLowerBounds)
+        public SpacePoint FindNextAscendingRa(double bounds)
         {
-            string query = $"select * from Subjects where ra > {RaLowerBounds} order by ra asc limit 1";
-            return GetPoint(query) ?? GetPoint(LowestRaQuery);
+            return GetPoint(NextAscendingRaQuery(bounds)) ?? GetPoint(LowestRaQuery);
         }
 
-        public SpacePoint FindNextDescendingRa(double RaUpperBounds)
+        public SpacePoint FindNextDescendingRa(double bounds)
         {
-            string query = $"select * from Subjects where ra < {RaUpperBounds} order by ra desc limit 1";
-            return GetPoint(query) ?? GetPoint(HighestRaQuery);
+            return GetPoint(NextDescendingRaQuery(bounds)) ?? GetPoint(HighestRaQuery);
         }
 
-        public SpacePoint FindNextAscendingDec(double DecLowerBounds)
+        public SpacePoint FindNextAscendingDec(double bounds)
         {
-            string query = $"select * from Subjects where dec > {DecLowerBounds} order by dec asc limit 1";
-            return GetPoint(query) ?? GetPoint(LowestDecQuery);
+            return GetPoint(NextAscendingDecQuery(bounds)) ?? GetPoint(LowestDecQuery);
         }
 
-        public SpacePoint FindNextDescendingDec(double DecUpperBounds)
+        public SpacePoint FindNextDescendingDec(double bounds)
         {
-            string query = $"select * from Subjects where dec < {DecUpperBounds} order by dec desc limit 1";
-            return GetPoint(query) ?? GetPoint(HighestDecQuery);
+            return GetPoint(NextDescendingDecQuery(bounds)) ?? GetPoint(HighestDecQuery);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -18,6 +18,8 @@ namespace GalaxyZooTouchTable.ViewModels
         private IGraphQLService _graphQLService;
         private IPanoptesService _panoptesService;
         private TableSubject CurrentGalaxy { get; set; }
+        private ILocalDBService _localDBService;
+
         private string CurrentTaskIndex { get; set; }
         private DispatcherTimer StillThereTimer { get; set; } = new DispatcherTimer();
 
@@ -139,10 +141,11 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _allowSelection, value);
         }
 
-        public ClassificationPanelViewModel(IPanoptesService panoptesService, IGraphQLService graphQLService, TableUser user)
+        public ClassificationPanelViewModel(IPanoptesService panoptesService, IGraphQLService graphQLService, ILocalDBService localDBService, TableUser user)
         {
             _panoptesService = panoptesService;
             _graphQLService = graphQLService;
+            _localDBService = localDBService;
             User = user;
 
             ExamplesViewModel = new ExamplesPanelViewModel();
@@ -212,7 +215,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             NotifySpaceView(RingNotifierStatus.IsHelping);
             TotalVotes = 0;
-            TableSubject newSubject = LocalDBService.GetLocalSubject(subjectID);
+            TableSubject newSubject = _localDBService.GetLocalSubject(subjectID);
             Subjects.Insert(0, newSubject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
@@ -367,7 +370,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 {
                     { "workflow_id", Config.WorkflowId }
                 };
-                Subjects = LocalDBService.GetQueuedSubjects();
+                Subjects = _localDBService.GetQueuedSubjects();
             }
             if (Subjects.Count > 0)
             {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -14,8 +14,8 @@ namespace GalaxyZooTouchTable.ViewModels
     public class SpaceViewModel : ViewModelBase
     {
         private IPanoptesService _panoptesService;
-        public double RA { get; set; } = 250.3035;
-        public double DEC { get; set; } = 35.09;
+        public double RA { get; set; } = 257.9;
+        public double DEC { get; set; } = 23.23;
         public double PLATE_SCALE { get; set; } = 1.5;
 
         private double RaRange { get; set; }
@@ -43,8 +43,8 @@ namespace GalaxyZooTouchTable.ViewModels
         public SpaceViewModel(IPanoptesService panoptesService)
         {
             _panoptesService = panoptesService;
-            PrepareForNewPosition();
             GetRange();
+            PrepareForNewPosition();
             LoadCommands();
             Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
         }
@@ -97,25 +97,25 @@ namespace GalaxyZooTouchTable.ViewModels
         private void OnMoveViewWest(object obj)
         {
             RA += RaRange;
-            GetSpaceCutout();
+            PrepareForNewPosition();
         }
 
         private void OnMoveViewSouth(object obj)
         {
             DEC -= DecRange;
-            GetSpaceCutout();
+            PrepareForNewPosition();
         }
 
         private void OnMoveViewEast(object obj)
         {
             RA -= RaRange;
-            GetSpaceCutout();
+            PrepareForNewPosition();
         }
 
         private void OnMoveViewNorth(object obj)
         {
             DEC += DecRange;
-            GetSpaceCutout();
+            PrepareForNewPosition();
         }
 
         private void GetSpaceCutout()
@@ -123,10 +123,15 @@ namespace GalaxyZooTouchTable.ViewModels
             SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={RA}&dec={DEC}&width=1248&height=432&scale={PLATE_SCALE}";
         }
 
-        private async void PrepareForNewPosition()
+        private void PrepareForNewPosition()
         {
             GetSpaceCutout();
-            await GetSubjectsAsync();
+
+            double minRa = RA - (RaRange / 2);
+            double maxRa = RA + (RaRange / 2);
+            double minDec = DEC - (DecRange / 2);
+            double maxDec = DEC + (DecRange / 2);
+            CurrentGalaxies = LocalDBService.GetLocalSubjects(minRa, maxRa, minDec, maxDec);
         }
 
         private async Task GetSubjectsAsync()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -1,4 +1,4 @@
-using GalaxyZooTouchTable.Lib;
+﻿using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
@@ -21,6 +21,21 @@ namespace GalaxyZooTouchTable.ViewModels
         public ICommand MoveViewEast { get; private set; }
         public ICommand MoveViewSouth { get; private set; }
         public ICommand MoveViewWest { get; private set; }
+        public ICommand HideError { get; private set; }
+
+        private bool _showError = false;
+        public bool ShowError
+        {
+            get => _showError;
+            set => SetProperty(ref _showError, value);
+        }
+
+        private string _errorMessage = "error error";
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set => SetProperty(ref _errorMessage, value);
+        }
 
         private List<TableSubject> _currentGalaxies = new List<TableSubject>();
         public List<TableSubject> CurrentGalaxies
@@ -48,6 +63,7 @@ namespace GalaxyZooTouchTable.ViewModels
             PrepareForNewPosition();
             LoadCommands();
             Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
+            Messenger.Default.Register<string>(this, OnShowError, "DatabaseError");
         }
 
         private void OnGalaxyInteraction(ClassificationRingNotifier RingNotifier)
@@ -98,6 +114,18 @@ namespace GalaxyZooTouchTable.ViewModels
             MoveViewEast = new CustomCommand(OnMoveViewEast);
             MoveViewSouth = new CustomCommand(OnMoveViewSouth);
             MoveViewWest = new CustomCommand(OnMoveViewWest);
+            HideError = new CustomCommand(OnHideError);
+        }
+
+        private void OnHideError(object obj)
+        {
+            ShowError = false;
+        }
+
+        private void OnShowError(string message)
+        {
+            ShowError = true;
+            ErrorMessage = message;
         }
 
         private void OnMoveViewWest(object obj)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -14,7 +14,7 @@ namespace GalaxyZooTouchTable.ViewModels
     public class SpaceViewModel : ViewModelBase
     {
         private IPanoptesService _panoptesService;
-
+        private ILocalDBService _localDBService;
         private double RaRange { get; set; }
         private double DecRange { get; set; }
 
@@ -37,11 +37,12 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _spaceCutoutUrl, value);
         }
 
-        public SpaceViewModel(IPanoptesService panoptesService)
+        public SpaceViewModel(IPanoptesService panoptesService, ILocalDBService localDBService)
         {
             _panoptesService = panoptesService;
+            _localDBService = localDBService;
 
-            SpacePoint StartingLocation = LocalDBService.GetRandomPoint();
+            SpacePoint StartingLocation = _localDBService.GetRandomPoint();
             SpaceNavigation.RA = StartingLocation.RightAscension;
             SpaceNavigation.DEC = StartingLocation.Declination;
             GetRange();
@@ -103,7 +104,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentGalaxies.Count == 0)
             {
                 double NewBounds = SpaceNavigation.RA + (RaRange / 2);
-                SpacePoint newCenter = LocalDBService.FindNextAscendingRa(NewBounds);
+                SpacePoint newCenter = _localDBService.FindNextAscendingRa(NewBounds);
                 SpaceNavigation.RA = newCenter.RightAscension;
                 SpaceNavigation.DEC = newCenter.Declination;
                 PrepareForNewPosition();
@@ -118,7 +119,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentGalaxies.Count == 0)
             {
                 double NewBounds = SpaceNavigation.DEC - (DecRange / 2);
-                SpacePoint newCenter = LocalDBService.FindNextDescendingDec(NewBounds);
+                SpacePoint newCenter = _localDBService.FindNextDescendingDec(NewBounds);
                 SpaceNavigation.RA = newCenter.RightAscension;
                 SpaceNavigation.DEC = newCenter.Declination;
                 PrepareForNewPosition();
@@ -133,7 +134,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentGalaxies.Count == 0)
             {
                 double NewBounds = SpaceNavigation.RA - (RaRange / 2);
-                SpacePoint newCenter = LocalDBService.FindNextDescendingRa(NewBounds);
+                SpacePoint newCenter = _localDBService.FindNextDescendingRa(NewBounds);
                 SpaceNavigation.RA = newCenter.RightAscension;
                 SpaceNavigation.DEC = newCenter.Declination;
                 PrepareForNewPosition();
@@ -148,7 +149,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentGalaxies.Count == 0)
             {
                 double NewBounds = SpaceNavigation.DEC + (DecRange / 2);
-                SpacePoint newCenter = LocalDBService.FindNextAscendingDec(NewBounds);
+                SpacePoint newCenter = _localDBService.FindNextAscendingDec(NewBounds);
                 SpaceNavigation.RA = newCenter.RightAscension;
                 SpaceNavigation.DEC = newCenter.Declination;
                 PrepareForNewPosition();
@@ -168,7 +169,7 @@ namespace GalaxyZooTouchTable.ViewModels
             double maxRa = SpaceNavigation.RA + (RaRange / 2);
             double minDec = SpaceNavigation.DEC - (DecRange /2);
             double maxDec = SpaceNavigation.DEC + (DecRange / 2);
-            CurrentGalaxies = LocalDBService.GetLocalSubjects(minRa, maxRa, minDec, maxDec);
+            CurrentGalaxies = _localDBService.GetLocalSubjects(minRa, maxRa, minDec, maxDec);
         }
 
         private async Task GetSubjectsAsync()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -99,24 +99,60 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             SpaceNavigation.RA += RaRange;
             PrepareForNewPosition();
+
+            if (CurrentGalaxies.Count == 0)
+            {
+                double NewBounds = SpaceNavigation.RA + (RaRange / 2);
+                SpacePoint newCenter = LocalDBService.FindNextAscendingRa(NewBounds);
+                SpaceNavigation.RA = newCenter.RightAscension;
+                SpaceNavigation.DEC = newCenter.Declination;
+                PrepareForNewPosition();
+            }
         }
 
         private void OnMoveViewSouth(object obj)
         {
             SpaceNavigation.DEC -= DecRange;
             PrepareForNewPosition();
+
+            if (CurrentGalaxies.Count == 0)
+            {
+                double NewBounds = SpaceNavigation.DEC - (DecRange / 2);
+                SpacePoint newCenter = LocalDBService.FindNextDescendingDec(NewBounds);
+                SpaceNavigation.RA = newCenter.RightAscension;
+                SpaceNavigation.DEC = newCenter.Declination;
+                PrepareForNewPosition();
+            }
         }
 
         private void OnMoveViewEast(object obj)
         {
             SpaceNavigation.RA -= RaRange;
             PrepareForNewPosition();
+
+            if (CurrentGalaxies.Count == 0)
+            {
+                double NewBounds = SpaceNavigation.RA - (RaRange / 2);
+                SpacePoint newCenter = LocalDBService.FindNextDescendingRa(NewBounds);
+                SpaceNavigation.RA = newCenter.RightAscension;
+                SpaceNavigation.DEC = newCenter.Declination;
+                PrepareForNewPosition();
+            }
         }
 
         private void OnMoveViewNorth(object obj)
         {
             SpaceNavigation.DEC += DecRange;
             PrepareForNewPosition();
+
+            if (CurrentGalaxies.Count == 0)
+            {
+                double NewBounds = SpaceNavigation.DEC + (DecRange / 2);
+                SpacePoint newCenter = LocalDBService.FindNextAscendingDec(NewBounds);
+                SpaceNavigation.RA = newCenter.RightAscension;
+                SpaceNavigation.DEC = newCenter.Declination;
+                PrepareForNewPosition();
+            }
         }
 
         private void GetSpaceCutout()
@@ -128,7 +164,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             GetSpaceCutout();
 
-            double minRa = SpaceNavigation.RA - (RaRange / 2);
+            double minRa = SpaceNavigation.RA - (RaRange / 2); 
             double maxRa = SpaceNavigation.RA + (RaRange / 2);
             double minDec = SpaceNavigation.DEC - (DecRange /2);
             double maxDec = SpaceNavigation.DEC + (DecRange / 2);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -66,27 +66,27 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                //if (RingNotifier.SubjectId == SpaceViewGalaxy.Id)
-                //{
-                //    switch (RingNotifier.Status)
-                //    {
-                //        case RingNotifierStatus.IsCreating:
-                //            SpaceViewGalaxy.AddRing(RingNotifier.User);
-                //            break;
-                //        case RingNotifierStatus.IsSubmitting:
-                //            SpaceViewGalaxy.DimRing(RingNotifier.User);
-                //            break;
-                //        case RingNotifierStatus.IsHelping:
-                //            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                //            break;
-                //        default:
-                //            break;
-                //    }
-                //}
-                //else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
-                //{
-                //    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                //}
+                if (RingNotifier.SubjectId == SpaceViewGalaxy.Id)
+                {
+                    switch (RingNotifier.Status)
+                    {
+                        case RingNotifierStatus.IsCreating:
+                            SpaceViewGalaxy.AddRing(RingNotifier.User);
+                            break;
+                        case RingNotifierStatus.IsSubmitting:
+                            SpaceViewGalaxy.DimRing(RingNotifier.User);
+                            break;
+                        case RingNotifierStatus.IsHelping:
+                            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
+                {
+                    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                }
             }
         }
 
@@ -187,7 +187,8 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void GetSpaceCutout()
         {
-            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={SpaceNavigation.RA}&dec={SpaceNavigation.DEC}&width=1248&height=432&scale={1.8}";
+            double WidenedPlateScale = 1.8;
+            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={SpaceNavigation.RA}&dec={SpaceNavigation.DEC}&width=1248&height=432&scale={WidenedPlateScale}";
         }
 
         private void PrepareForNewPosition()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -4,6 +4,7 @@ using GalaxyZooTouchTable.Services;
 using PanoptesNetClient.Models;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Data.SQLite;
 using System.Threading.Tasks;
 
 namespace GalaxyZooTouchTable.ViewModels
@@ -62,7 +63,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 }
             }
         }
-        
+
         private void GetSpaceCutout()
         {
             SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={RA}&dec={DEC}&width=1248&height=432&scale={SCALE}";

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -12,7 +12,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private ILocalDBService _localDBService;
         private double RaRange { get; set; }
         private double DecRange { get; set; }
-        private SpaceNavigation CurrentLocation { get; set; }
+        public SpaceNavigation CurrentLocation { get; set; }
 
         public ICommand MoveViewNorth { get; private set; }
         public ICommand MoveViewEast { get; private set; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -1,18 +1,14 @@
-﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
-using PanoptesNetClient.Models;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
     public class SpaceViewModel : ViewModelBase
     {
-        private IPanoptesService _panoptesService;
         private ILocalDBService _localDBService;
         private double RaRange { get; set; }
         private double DecRange { get; set; }
@@ -51,14 +47,14 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _spaceCutoutUrl, value);
         }
 
-        public SpaceViewModel(IPanoptesService panoptesService, ILocalDBService localDBService)
+        public SpaceViewModel(ILocalDBService localDBService)
         {
-            _panoptesService = panoptesService;
             _localDBService = localDBService;
 
             SpacePoint StartingLocation = _localDBService.GetRandomPoint();
             SpaceNavigation.RA = StartingLocation.RightAscension;
             SpaceNavigation.DEC = StartingLocation.Declination;
+
             GetRange();
             PrepareForNewPosition();
             LoadCommands();
@@ -70,26 +66,27 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                if (RingNotifier.SubjectId == SpaceViewGalaxy.Subject.Id)
-                {
-                    switch (RingNotifier.Status)
-                    {
-                        case RingNotifierStatus.IsCreating:
-                            SpaceViewGalaxy.AddRing(RingNotifier.User);
-                            break;
-                        case RingNotifierStatus.IsSubmitting:
-                            SpaceViewGalaxy.DimRing(RingNotifier.User);
-                            break;
-                        case RingNotifierStatus.IsHelping:
-                            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                            break;
-                        default:
-                            break;
-                    }
-                } else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
-                {
-                    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                }
+                //if (RingNotifier.SubjectId == SpaceViewGalaxy.Id)
+                //{
+                //    switch (RingNotifier.Status)
+                //    {
+                //        case RingNotifierStatus.IsCreating:
+                //            SpaceViewGalaxy.AddRing(RingNotifier.User);
+                //            break;
+                //        case RingNotifierStatus.IsSubmitting:
+                //            SpaceViewGalaxy.DimRing(RingNotifier.User);
+                //            break;
+                //        case RingNotifierStatus.IsHelping:
+                //            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                //            break;
+                //        default:
+                //            break;
+                //    }
+                //}
+                //else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
+                //{
+                //    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                //}
             }
         }
 
@@ -202,20 +199,6 @@ namespace GalaxyZooTouchTable.ViewModels
             double minDec = SpaceNavigation.DEC - (DecRange /2);
             double maxDec = SpaceNavigation.DEC + (DecRange / 2);
             CurrentGalaxies = _localDBService.GetLocalSubjects(minRa, maxRa, minDec, maxDec);
-        }
-
-        private async Task GetSubjectsAsync()
-        {
-            NameValueCollection query = new NameValueCollection();
-            query.Add("workflow_id", Config.WorkflowId);
-            query.Add("page_size", "25");
-
-            var GalaxyList = await _panoptesService.GetSubjectsAsync("queued", query);
-            foreach (Subject subject in GalaxyList)
-            {
-                TableSubject Galaxy = new TableSubject(subject, RA, DEC);
-                CurrentGalaxies.Add(Galaxy);
-            }
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -14,9 +14,6 @@ namespace GalaxyZooTouchTable.ViewModels
     public class SpaceViewModel : ViewModelBase
     {
         private IPanoptesService _panoptesService;
-        public double RA { get; set; } = 257.9;
-        public double DEC { get; set; } = 23.23;
-        public double PLATE_SCALE { get; set; } = 1.5;
 
         private double RaRange { get; set; }
         private double DecRange { get; set; }
@@ -43,6 +40,10 @@ namespace GalaxyZooTouchTable.ViewModels
         public SpaceViewModel(IPanoptesService panoptesService)
         {
             _panoptesService = panoptesService;
+
+            SpacePoint StartingLocation = LocalDBService.GetRandomPoint();
+            SpaceNavigation.RA = StartingLocation.RightAscension;
+            SpaceNavigation.DEC = StartingLocation.Declination;
             GetRange();
             PrepareForNewPosition();
             LoadCommands();
@@ -82,8 +83,8 @@ namespace GalaxyZooTouchTable.ViewModels
             int CutoutHeight = 432;
             const int ArcDegreeInSeconds = 3600;
 
-            DecRange = CutoutHeight * PLATE_SCALE / ArcDegreeInSeconds;
-            RaRange = Math.Abs(CutoutWidth * PLATE_SCALE / ArcDegreeInSeconds / Math.Cos(DEC));
+            DecRange = CutoutHeight * SpaceNavigation.PlateScale / ArcDegreeInSeconds;
+            RaRange = Math.Abs(CutoutWidth * SpaceNavigation.PlateScale / ArcDegreeInSeconds / Math.Cos(SpaceNavigation.DEC));
         }
 
         private void LoadCommands()
@@ -96,41 +97,41 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnMoveViewWest(object obj)
         {
-            RA += RaRange;
+            SpaceNavigation.RA += RaRange;
             PrepareForNewPosition();
         }
 
         private void OnMoveViewSouth(object obj)
         {
-            DEC -= DecRange;
+            SpaceNavigation.DEC -= DecRange;
             PrepareForNewPosition();
         }
 
         private void OnMoveViewEast(object obj)
         {
-            RA -= RaRange;
+            SpaceNavigation.RA -= RaRange;
             PrepareForNewPosition();
         }
 
         private void OnMoveViewNorth(object obj)
         {
-            DEC += DecRange;
+            SpaceNavigation.DEC += DecRange;
             PrepareForNewPosition();
         }
 
         private void GetSpaceCutout()
         {
-            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={RA}&dec={DEC}&width=1248&height=432&scale={PLATE_SCALE}";
+            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={SpaceNavigation.RA}&dec={SpaceNavigation.DEC}&width=1248&height=432&scale={SpaceNavigation.PlateScale}";
         }
 
         private void PrepareForNewPosition()
         {
             GetSpaceCutout();
 
-            double minRa = RA - (RaRange / 2);
-            double maxRa = RA + (RaRange / 2);
-            double minDec = DEC - (DecRange / 2);
-            double maxDec = DEC + (DecRange / 2);
+            double minRa = SpaceNavigation.RA - (RaRange / 2);
+            double maxRa = SpaceNavigation.RA + (RaRange / 2);
+            double minDec = SpaceNavigation.DEC - (DecRange /2);
+            double maxDec = SpaceNavigation.DEC + (DecRange / 2);
             CurrentGalaxies = LocalDBService.GetLocalSubjects(minRa, maxRa, minDec, maxDec);
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -3,7 +3,6 @@ using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using PanoptesNetClient.Models;
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
@@ -85,7 +84,12 @@ namespace GalaxyZooTouchTable.ViewModels
             const int ArcDegreeInSeconds = 3600;
 
             DecRange = CutoutHeight * SpaceNavigation.PlateScale / ArcDegreeInSeconds;
-            RaRange = Math.Abs(CutoutWidth * SpaceNavigation.PlateScale / ArcDegreeInSeconds / Math.Cos(SpaceNavigation.DEC));
+            RaRange = (CutoutWidth * SpaceNavigation.PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(SpaceNavigation.DEC))));
+        }
+
+        private double ToRadians(double Degrees)
+        {
+            return (Degrees * System.Math.PI) / 180.0;
         }
 
         private void LoadCommands()
@@ -158,7 +162,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void GetSpaceCutout()
         {
-            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={SpaceNavigation.RA}&dec={SpaceNavigation.DEC}&width=1248&height=432&scale={SpaceNavigation.PlateScale}";
+            SpaceCutoutUrl = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={SpaceNavigation.RA}&dec={SpaceNavigation.DEC}&width=1248&height=432&scale={1.8}";
         }
 
         private void PrepareForNewPosition()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -1,10 +1,9 @@
-﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using PanoptesNetClient.Models;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Data.SQLite;
 using System.Threading.Tasks;
 
 namespace GalaxyZooTouchTable.ViewModels

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
@@ -16,6 +16,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public ViewModelLocator()
         {
             container.RegisterType<IPanoptesService, PanoptesService>();
+            container.RegisterType<ILocalDBService, LocalDBService>();
             _spaceViewModel = container.Resolve<SpaceViewModel>();
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
@@ -15,7 +15,6 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public ViewModelLocator()
         {
-            container.RegisterType<IPanoptesService, PanoptesService>();
             container.RegisterType<ILocalDBService, LocalDBService>();
             _spaceViewModel = container.Resolve<SpaceViewModel>();
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -73,7 +73,7 @@
                 <DataTemplate>
                     <Image Style="{StaticResource UserAvatar}" Width="26" Height="26" Source="{Binding UserAvatar}">
                         <Image.RenderTransform>
-                            <TranslateTransform X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
+                            <TranslateTransform x:Name="TransformAvatar" X="{Binding AvatarX}" Y="{Binding AvatarY}"/>
                         </Image.RenderTransform>
                     </Image>
                 </DataTemplate>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -53,6 +53,9 @@
         </ItemsControl>
 
         <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <i:Interaction.Behaviors>
+                <Behaviors:TapBehavior Command="{Binding MoveViewNorth}"/>
+            </i:Interaction.Behaviors>
             <Border.LayoutTransform>
                 <RotateTransform Angle="180"/>
             </Border.LayoutTransform>
@@ -60,6 +63,9 @@
         </Border>
 
         <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Top">
+            <i:Interaction.Behaviors>
+                <Behaviors:TapBehavior Command="{Binding MoveViewEast}"/>
+            </i:Interaction.Behaviors>
             <Border.LayoutTransform>
                 <RotateTransform Angle="-90"/>
             </Border.LayoutTransform>
@@ -67,6 +73,9 @@
         </Border>
 
         <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Bottom">
+            <i:Interaction.Behaviors>
+                <Behaviors:TapBehavior Command="{Binding MoveViewWest}"/>
+            </i:Interaction.Behaviors>
             <Border.LayoutTransform>
                 <RotateTransform Angle="90"/>
             </Border.LayoutTransform>
@@ -74,6 +83,9 @@
         </Border>
 
         <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+            <i:Interaction.Behaviors>
+                <Behaviors:TapBehavior Command="{Binding MoveViewSouth}"/>
+            </i:Interaction.Behaviors>
             <TextBlock Style="{StaticResource MoveMapText}"/>
         </Border>
     </Grid>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -28,6 +28,15 @@
             <Setter Property="Text" Value="Move map"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
+
+        <Style x:Key="ErrorPanel" TargetType="{x:Type StackPanel}">
+            <Setter Property="Visibility" Value="Visible"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=ShowError}" Value="False">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
 
     <Grid>
@@ -88,5 +97,9 @@
             </i:Interaction.Behaviors>
             <TextBlock Style="{StaticResource MoveMapText}"/>
         </Border>
+        <StackPanel Style="{StaticResource ErrorPanel}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Orientation="Horizontal">
+            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red"/>
+            <Button Content="X" Command="{Binding HideError}" Foreground="White" Background="Transparent" Margin="5,0" BorderThickness="0"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
              xmlns:views="clr-namespace:GalaxyZooTouchTable.Views"
              mc:Ignorable="d" 
              Height="432"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/packages.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="FontAwesome.WPF" version="4.7.0.9" targetFramework="net461" />
   <package id="GraphQL.Client" version="2.0.0-alpha.2" targetFramework="net461" />
   <package id="GraphQL.Common" version="2.0.0-alpha.2" targetFramework="net461" />
@@ -7,7 +8,17 @@
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="PanoptesNetClient" version="1.1.1" targetFramework="net461" />
+  <package id="SQLitePCLRaw.bundle_green" version="1.1.13" targetFramework="net461" />
+  <package id="SQLitePCLRaw.core" version="1.1.13" targetFramework="net461" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.13" targetFramework="net461" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.13" targetFramework="net461" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.13" targetFramework="net461" />
+  <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.13" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="4.4.1" targetFramework="net461" />
+  <package id="System.Data.SQLite" version="1.0.110.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Core" version="1.0.110.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.EF6" version="1.0.110.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Linq" version="1.0.110.0" targetFramework="net461" />
   <package id="System.Net.WebSockets" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.WebSockets.Client" version="4.3.2" targetFramework="net461" />
   <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Galaxy Zoo Touch Table
 The Galaxy Zoo touch table experience at the Adler Planetarium.
 
+## Prerequisites
+-[Local Database](#using-a-local-database)
+
 ## Publishing
 Currently, the app is setup to publish through a ClickOnce wizard with Google Drive File Stream, which should be setup on the local computer and synced to the Zooniverse Citizen Science team drive. Publishing can be made directly to the Touch Table folder under that drive. The Publish Version should be incremented to avoid errors with conflicting previous versions.
 
 ## Installing
 Likewise, the app can be installed via the same Google Drive File Stream location (Zooniverse/Citizen Science/Touch Table/Setup). It may be necessary to uninstall older versions of the app if conflicts appear during setup.
+
+## Using a Local Database
+The touch table is setup to use a local database to query subject locations based on Right Ascension and Declination. In order for the app to run correctly, a SQLite database (.db) should be inserted in the system's "Documents" folder with the following paths:
+
+-**Staging:** GZ_Staging_Subjects.db
+-**Production:** GZ_Production_Subjects.db
+
+To create the database, a subject export (.csv) retrieved from Panoptes must be preprocessed using a Python script. That .csv can then be imported into a database. I've used the [SQLiteStudio GUI](https://sqlitestudio.pl/index.rvt) to import CSVs.  
 
 [![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Galaxy Zoo touch table experience at the Adler Planetarium.
 
 ## Prerequisites
--[Local Database](#using-a-local-database)
+- [Local Database](#using-a-local-database)
 
 ## Publishing
 Currently, the app is setup to publish through a ClickOnce wizard with Google Drive File Stream, which should be setup on the local computer and synced to the Zooniverse Citizen Science team drive. Publishing can be made directly to the Touch Table folder under that drive. The Publish Version should be incremented to avoid errors with conflicting previous versions.
@@ -13,9 +13,21 @@ Likewise, the app can be installed via the same Google Drive File Stream locatio
 ## Using a Local Database
 The touch table is setup to use a local database to query subject locations based on Right Ascension and Declination. In order for the app to run correctly, a SQLite database (.db) should be inserted in the system's "Documents" folder with the following paths:
 
--**Staging:** GZ_Staging_Subjects.db
--**Production:** GZ_Production_Subjects.db
+- **Staging:** GZ_Staging_Subjects.db
+- **Production:** GZ_Production_Subjects.db
 
 To create the database, a subject export (.csv) retrieved from Panoptes must be preprocessed using a Python script. That .csv can then be imported into a database. I've used the [SQLiteStudio GUI](https://sqlitestudio.pl/index.rvt) to import CSVs.  
+
+The local database has the following structure:
+
+```
+CREATE TABLE Subjects(
+    subject_id STRING,
+    classification_count INTEGER,
+    ra DOUBLE,
+    dec DOUBLE,
+    image STRING
+);
+```
 
 [![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)


### PR DESCRIPTION
Describe your changes.
This PR introduces a local database into the mix for retrieving subjects. This is the first step towards having an offline-first app. Notice, this branch contains functionality for a staging DB. The production DB will be added in later. Refer to the README on how to set up the database.

There's a good bit of refactoring in this branch as well. A good bit of it seeks to remove the ambiguity between `Subject` (straight from the Panoptes API) and `TableSubject` (optimized for the table). Having two similar items is confusing, so a good bit of the code here removes the `Subject` references.

# Review Checklist

- [X] Are tests passing?
- [X] Is the build free of output errors?
