### PR TITLE
Adjust drop area

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/NotificationsViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/NotificationsViewModelTests.cs
@@ -208,5 +208,13 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             Assert.NotNull(_viewModel.NotificationPanel);
             Assert.Equal(NotificationPanelStatus.ShowAnswer, _viewModel.NotificationPanel.Status);
         }
+
+        [Fact]
+        void ShouldNotifyAlreadyAnswered()
+        {
+            _viewModel.AlreadySeen();
+            Assert.NotNull(_viewModel.Overlay);
+            Assert.Equal("You have already classified this galaxy.", _viewModel.Overlay.MessageOne);
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/TapBehavior.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/TapBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interactivity;
 
@@ -19,6 +20,7 @@ namespace GalaxyZooTouchTable.Behaviors
 
             AssociatedObject.TouchDown += AssociatedObject_TouchDown;
             AssociatedObject.TouchUp += AssociatedObject_TouchUp;
+            AssociatedObject.TouchLeave += AssociatedObject_TouchLeave;
         }
 
         /// <summary>
@@ -40,8 +42,13 @@ namespace GalaxyZooTouchTable.Behaviors
             IsTouchDown = true;
         }
 
+        private void AssociatedObject_TouchLeave(object sender, TouchEventArgs e)
+        {
+            IsTouchDown = false;
+        }
+
         public static readonly DependencyProperty HandleProperty =
-            DependencyProperty.Register("Handle", typeof(bool), typeof(TapBehavior), new UIPropertyMetadata(true));
+            DependencyProperty.Register("Handle", typeof(bool), typeof(TapBehavior), new UIPropertyMetadata(false));
 
         public bool Handle
         {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/GalaxyAdorner.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/GalaxyAdorner.cs
@@ -7,39 +7,39 @@ using System.Windows.Media;
 namespace GalaxyZooTouchTable.Lib
 {
     public class GalaxyAdorner : Adorner
+    {
+        public Point Location;
+        public Point Offset;
+        public EventHandler<TouchEventArgs> UnsubscribeEvent { get; set; }
+
+        public GalaxyAdorner(FrameworkElement adornedElement, Point offset)
+          : base(adornedElement)
         {
-            public Point Location;
-            public Point Offset;
-            public EventHandler<TouchEventArgs> UnsubscribeEvent { get; set; }
-
-            public GalaxyAdorner(FrameworkElement adornedElement, Point offset)
-              : base(adornedElement)
-            {
-                Offset = offset;
-                DataContext = adornedElement.DataContext;
-                IsHitTestVisible = false;
-            }
-
-            public void UpdatePosition(Point location)
-            {
-                Location = location;
-                this.InvalidateVisual();
-            }
-
-            protected override void OnRender(DrawingContext drawingContext)
-            {
-                var adornerLocation = Location;
-                adornerLocation.Offset(-Offset.X, -Offset.Y);
-
-                Rect adornedElementRect = new Rect(adornerLocation, AdornedElement.DesiredSize);
-
-                var visualBrush = new VisualBrush(AdornedElement);
-                Pen border = new Pen(new SolidColorBrush(Color.FromRgb(229,255,77)), 1.5);
-
-                drawingContext.DrawRoundedRectangle(
-                    visualBrush, border, adornedElementRect,
-                    this.AdornedElement.DesiredSize.Width / 2,
-                    this.AdornedElement.DesiredSize.Height / 2);
-            }
+            Offset = offset;
+            DataContext = adornedElement.DataContext;
+            IsHitTestVisible = false;
         }
+
+        public void UpdatePosition(Point location)
+        {
+            Location = location;
+            this.InvalidateVisual();
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            var adornerLocation = Location;
+            adornerLocation.Offset(-Offset.X, -Offset.Y);
+
+            Rect adornedElementRect = new Rect(adornerLocation, AdornedElement.DesiredSize);
+
+            var visualBrush = new VisualBrush(AdornedElement);
+            Pen border = new Pen(new SolidColorBrush(Color.FromRgb(229,255,77)), 1.5);
+
+            drawingContext.DrawRoundedRectangle(
+                visualBrush, border, adornedElementRect,
+                this.AdornedElement.DesiredSize.Width / 2,
+                this.AdornedElement.DesiredSize.Height / 2);
+        }
+    }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,5 +1,6 @@
 ﻿using PanoptesNetClient.Models;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace GalaxyZooTouchTable.Models
 {
@@ -91,6 +92,11 @@ namespace GalaxyZooTouchTable.Models
         private double ToRadians(double Degrees)
         {
             return (Degrees * System.Math.PI) / 180.0;
+        }
+
+        public bool IsWorkingWithUser(TableUser user)
+        {
+            return GalaxyRings.Any(X => X.UserName == user.Name && X.CurrentlyClassifying);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -222,7 +222,6 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public void OnGetSubjectById(string subjectID)
         {
-            NotifySpaceView(RingNotifierStatus.IsHelping);
             TotalVotes = 0;
             TableSubject newSubject = _localDBService.GetLocalSubject(subjectID);
             Subjects.Insert(0, newSubject);
@@ -278,7 +277,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 NotifySpaceView(RingNotifierStatus.IsSubmitting);
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
-                await _panoptesService.CreateClassificationAsync(CurrentClassification);
+                //await _panoptesService.CreateClassificationAsync(CurrentClassification);
                 SelectedAnswer.AnswerCount += 1;
                 TotalVotes += 1;
                 ClassificationsThisSession += 1;
@@ -298,7 +297,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void NotifySpaceView(RingNotifierStatus Status)
         {
             ClassificationRingNotifier Notification = new ClassificationRingNotifier(CurrentSubject, User, Status);
-            Messenger.Default.Send<ClassificationRingNotifier>(Notification);
+            Messenger.Default.Send(Notification);
         }
 
         private void SetTimer()
@@ -385,6 +384,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public void DropSubject(TableSubject subject)
         {
+            if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             TotalVotes = 0;
             Subjects.Insert(0, subject);
             GetSubjectQueue();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -4,9 +4,11 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using GraphQL.Common.Response;
 using PanoptesNetClient.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -277,7 +279,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 NotifySpaceView(RingNotifierStatus.IsSubmitting);
                 CurrentClassification.Metadata.FinishedAt = System.DateTime.Now.ToString();
                 CurrentClassification.Annotations.Add(CurrentAnnotation);
-                //await _panoptesService.CreateClassificationAsync(CurrentClassification);
+                await _panoptesService.CreateClassificationAsync(CurrentClassification);
                 SelectedAnswer.AnswerCount += 1;
                 TotalVotes += 1;
                 ClassificationsThisSession += 1;
@@ -384,12 +386,20 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public void DropSubject(TableSubject subject)
         {
+            if (CheckAlreadyCompleted(subject)) return;
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             TotalVotes = 0;
             Subjects.Insert(0, subject);
             GetSubjectQueue();
             SubjectView = SubjectViewEnum.MatchedSubject;
             NotifySpaceView(RingNotifierStatus.IsCreating);
+        }
+
+        private bool CheckAlreadyCompleted(TableSubject subject)
+        {
+            bool AlreadyCompleted = CompletedClassifications.Any(x => x.SubjectId == subject.Id);
+            if (AlreadyCompleted) Notifications.AlreadySeen();
+            return AlreadyCompleted;
         }
 
         public void ResetAnswerCount()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ExamplesPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ExamplesPanelViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Utility;
+using System;
 using System.Windows.Input;
 
 namespace GalaxyZooTouchTable.ViewModels
@@ -9,7 +10,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public ICommand OpenPanel { get; private set; }
         public ICommand TogglePanel { get; private set; }
         public ICommand SelectItem { get; private set; }
-        public ICommand UnselectItem { get; private set; }
+        public ICommand ToggleItem { get; private set; }
 
         public GalaxyExample Smooth { get; set; } = GalaxyExampleFactory.Create(GalaxyType.Smooth);
         public GalaxyExample Features { get; set; } = GalaxyExampleFactory.Create(GalaxyType.Features);
@@ -56,7 +57,7 @@ namespace GalaxyZooTouchTable.ViewModels
             OpenPanel = new CustomCommand(SlidePanel, CanOpen);
             TogglePanel = new CustomCommand(SlidePanel, CanToggle);
             SelectItem = new CustomCommand(OnToggleItem, CanSelectItem);
-            UnselectItem = new CustomCommand(OnToggleItem);
+            ToggleItem = new CustomCommand(OnToggleItem);
         }
 
         public void OnToggleItem(object sender)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
@@ -337,6 +337,11 @@ namespace GalaxyZooTouchTable.ViewModels
             NotifierIsOpen = !NotifierIsOpen;
         }
 
+        public void AlreadySeen()
+        {
+            Overlay = new NotificationOverlay("You have already classified this galaxy.");
+        }
+
         public void ReceivedNewSubject(TableSubject subject)
         {
             bool HardReset = false;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -2,6 +2,7 @@ using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
+using System;
 using System.Collections.Generic;
 using System.Windows.Input;
 
@@ -69,28 +70,31 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             foreach (TableSubject SpaceViewGalaxy in CurrentGalaxies)
             {
-                if (RingNotifier.SubjectId == SpaceViewGalaxy.Id)
+                if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
+                {
+                    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
+                } else if (RingNotifier.SubjectId == SpaceViewGalaxy.Id)
                 {
                     switch (RingNotifier.Status)
                     {
                         case RingNotifierStatus.IsCreating:
+                            RemoveAllActiveRingsByUser(RingNotifier.User);
                             SpaceViewGalaxy.AddRing(RingNotifier.User);
                             break;
                         case RingNotifierStatus.IsSubmitting:
                             SpaceViewGalaxy.DimRing(RingNotifier.User);
                             break;
-                        case RingNotifierStatus.IsHelping:
-                            SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                            break;
                         default:
                             break;
                     }
                 }
-                else if (RingNotifier.Status == RingNotifierStatus.IsLeaving)
-                {
-                    SpaceViewGalaxy.RemoveRing(RingNotifier.User);
-                }
             }
+        }
+
+        void RemoveAllActiveRingsByUser(TableUser user)
+        {
+            TableSubject Galaxy = CurrentGalaxies.Find(x => x.IsWorkingWithUser(user));
+            if (Galaxy != null) Galaxy.RemoveRing(user);
         }
 
         private void LoadCommands()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using GalaxyZooTouchTable.ViewModels;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace GalaxyZooTouchTable
 {
@@ -19,6 +20,11 @@ namespace GalaxyZooTouchTable
             var Element = sender as FrameworkElement;
             ClassificationPanelViewModel Classifier = Element.DataContext as ClassificationPanelViewModel;
             Classifier.StartStillThereModalTimer();
+        }
+
+        protected override System.Windows.Media.HitTestResult HitTestCore(System.Windows.Media.PointHitTestParameters hitTestParameters)
+        {
+            return new PointHitTestResult(this, hitTestParameters.HitPoint);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationSummary.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationSummary.xaml.cs
@@ -1,15 +1,37 @@
-﻿using System.Windows.Controls;
+﻿using GalaxyZooTouchTable.Models;
+using GalaxyZooTouchTable.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace GalaxyZooTouchTable
 {
     /// <summary>
     /// Interaction logic for ClassificationSummary.xaml
     /// </summary>
-    public partial class ClassificationSummary : UserControl
+    public partial class ClassificationSummary : UserControl, IDroppableArea
     {
         public ClassificationSummary()
         {
             InitializeComponent();
+        }
+
+        public bool IsUnder(Point p)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        void IDroppableArea.Drop(FrameworkElement element)
+        {
+            TableSubject passedSubject = element.DataContext as TableSubject;
+            ClassificationPanelViewModel viewModel = DataContext as ClassificationPanelViewModel;
+
+            viewModel.DropSubject(passedSubject);
+        }
+
+        protected override System.Windows.Media.HitTestResult HitTestCore(System.Windows.Media.PointHitTestParameters hitTestParameters)
+        {
+            return new PointHitTestResult(this, hitTestParameters.HitPoint);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/DropZone.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/DropZone.xaml.cs
@@ -1,38 +1,15 @@
-﻿using GalaxyZooTouchTable.Models;
-using GalaxyZooTouchTable.ViewModels;
-using System;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
+﻿using System.Windows.Controls;
 
 namespace GalaxyZooTouchTable.Views
 {
     /// <summary>
     /// Interaction logic for DropZone.xaml
     /// </summary>
-    public partial class DropZone : UserControl, IDroppableArea
+    public partial class DropZone : UserControl
     {
         public DropZone()
         {
             InitializeComponent();
-        }
-
-        public bool IsUnder(Point p)
-        {
-            throw new NotImplementedException();
-        }
-
-        void IDroppableArea.Drop(FrameworkElement element)
-        {
-            TableSubject passedSubject = element.DataContext as TableSubject;
-            ClassificationPanelViewModel viewModel = DataContext as ClassificationPanelViewModel;
-
-            viewModel.DropSubject(passedSubject);
-        }
-
-        protected override System.Windows.Media.HitTestResult HitTestCore(System.Windows.Media.PointHitTestParameters hitTestParameters)
-        {
-            return new PointHitTestResult(this, hitTestParameters.HitPoint);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -406,19 +406,21 @@
                 <TranslateTransform X="{Binding Path=ActualWidth, ElementName=Panel, Converter={StaticResource HidePanelConverter}, ConverterParameter='-0.75'}"/>
             </Border.RenderTransform>
 
-            <Canvas Background="Transparent">
-                <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding OpenPanel}"/>
-                </i:Interaction.Behaviors>
+            <Canvas>
+                <Grid Margin="0,37,0,0" Background="Transparent" Height="181.2" Width="{Binding Path=ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Canvas}}">
+                    <i:Interaction.Behaviors>
+                        <Behaviors:TapBehavior Command="{Binding OpenPanel}"/>
+                    </i:Interaction.Behaviors>
+                </Grid>
 
-                <Grid Canvas.Left="18" Canvas.Top="10.2" Width="102">
+                <Grid Width="131" Height="37">
                     <i:Interaction.Behaviors>
                         <Behaviors:TapBehavior Command="{Binding TogglePanel}"/>
                     </i:Interaction.Behaviors>
 
-                    <TextBlock Style="{StaticResource ExampleText}"/>
-                    <TextBlock Margin="0,12,0,0" Text="Tap each item to learn more." FontSize="7" Foreground="White" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla" FontStyle="Italic"/>
-                    <fa:ImageAwesome Style="{StaticResource ToggleArrowStyle}">
+                    <TextBlock Margin="18,10,0,0" Style="{StaticResource ExampleText}"/>
+                    <TextBlock Margin="18,22,0,0" Text="Tap each item to learn more." FontSize="7" Foreground="White" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla" FontStyle="Italic"/>
+                    <fa:ImageAwesome Margin="0,10,14,0" Style="{StaticResource ToggleArrowStyle}">
                         <fa:ImageAwesome.RenderTransform>
                             <TransformGroup>
                                 <RotateTransform/>
@@ -443,7 +445,7 @@
 
                     <Grid Style="{StaticResource ExampleGrid}" TouchUp="SmoothStackPanel_TouchUp">
                         <i:Interaction.Behaviors>
-                            <Behaviors:TapBehavior Command="{Binding UnselectItem}" CommandParameter="{Binding Smooth}"/>
+                            <Behaviors:TapBehavior Command="{Binding ToggleItem}" CommandParameter="{Binding Smooth}" Handle="{Binding IsSelected}"/>
                         </i:Interaction.Behaviors>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Smooth"/>
@@ -501,7 +503,7 @@
 
                     <Grid Style="{StaticResource ExampleGrid}" TouchUp="FeaturesStackPanel_TouchUp">
                         <i:Interaction.Behaviors>
-                            <Behaviors:TapBehavior Command="{Binding UnselectItem}" CommandParameter="{Binding Features}"/>
+                            <Behaviors:TapBehavior Command="{Binding ToggleItem}" CommandParameter="{Binding Features}" Handle="{Binding IsSelected}"/>
                         </i:Interaction.Behaviors>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Features"/>
@@ -559,7 +561,7 @@
                     
                     <Grid Style="{StaticResource ExampleGrid}" TouchUp="NotAGalaxyStackPanel_TouchUp">
                         <i:Interaction.Behaviors>
-                            <Behaviors:TapBehavior Command="{Binding UnselectItem}" CommandParameter="{Binding NotAGalaxy}"/>
+                            <Behaviors:TapBehavior Command="{Binding ToggleItem}" CommandParameter="{Binding NotAGalaxy}" Handle="True"/>
                         </i:Interaction.Behaviors>
 
                         <TextBlock Style="{StaticResource ExampleTextBlock}" Text="Not a Galaxy"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StartButton.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StartButton.xaml
@@ -41,7 +41,7 @@
         BorderThickness="0"
         Style="{StaticResource StartButtonStyle}">
         <i:Interaction.Behaviors>
-            <Behaviors:TapBehavior Command="{Binding OpenClassifier}" Handle="False"/>
+            <Behaviors:TapBehavior Command="{Binding OpenClassifier}"/>
         </i:Interaction.Behaviors>
         <Button.RenderTransform>
             <TranslateTransform Y="{Binding Path=ActualHeight, ElementName=ButtonContainer, Converter={StaticResource HidePanelConverter}, ConverterParameter='1'}"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SubjectViewer.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SubjectViewer.xaml.cs
@@ -1,15 +1,37 @@
-﻿using System.Windows.Controls;
+﻿using GalaxyZooTouchTable.Models;
+using GalaxyZooTouchTable.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace GalaxyZooTouchTable
 {
     /// <summary>
     /// Interaction logic for SubjectViewer.xaml
     /// </summary>
-    public partial class SubjectViewer : UserControl
+    public partial class SubjectViewer : UserControl, IDroppableArea
     {
         public SubjectViewer()
         {
             InitializeComponent();
+        }
+
+        public bool IsUnder(Point p)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        void IDroppableArea.Drop(FrameworkElement element)
+        {
+            TableSubject passedSubject = element.DataContext as TableSubject;
+            ClassificationPanelViewModel viewModel = DataContext as ClassificationPanelViewModel;
+
+            viewModel.DropSubject(passedSubject);
+        }
+
+        protected override System.Windows.Media.HitTestResult HitTestCore(System.Windows.Media.PointHitTestParameters hitTestParameters)
+        {
+            return new PointHitTestResult(this, hitTestParameters.HitPoint);
         }
     }
 }


### PR DESCRIPTION
Describe your changes.

This PR fixes several items:
- Allow users to advance the classifier and classify a galaxy when dropping a galaxy anywhere on the `SubjectViewer` or `ClassificationSummary`.
- Restricts users from classifying the same galaxy more than once by dragging it onto their classifier. 
- Fixed a bug where users could drop a galaxy onto their leveler or examples panel without the galaxy disappearing. This arose from the galaxy drop event being handled before the drag overlay could clean up and remove the galaxy.

Fixes #48 
Closes #56 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
