### PR TITLE
Add intent button

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\CenterpieceViewModelTests.cs" />
     <Compile Include="ViewModels\ClassificationPanelViewModelTests.cs" />
+    <Compile Include="ViewModels\CloseConfirmationViewModelTests.cs" />
     <Compile Include="ViewModels\ExamplesPanelViewModelTests.cs" />
     <Compile Include="ViewModels\LevelerViewModelTests.cs" />
     <Compile Include="ViewModels\NotificationsViewModelTests.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -40,6 +40,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         {
             Assert.False(_viewModel.ClassifierOpen);
             Assert.False(_viewModel.CanSendClassification);
+            Assert.False(_viewModel.ShowOverlay);
         }
 
         [Fact]
@@ -187,6 +188,13 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _viewModel.ResetAnswerCount();
             Assert.Equal(0, _viewModel.CurrentAnswers[0].AnswerCount);
             Assert.Equal(0, _viewModel.CurrentAnswers[1].AnswerCount);
+        }
+
+        [Fact]
+        private void ShouldShowOverlay()
+        {
+            _viewModel.ShowCloseConfirmation.Execute(null);
+            Assert.True(_viewModel.ShowOverlay);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -38,7 +38,6 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private void ShouldInitializeWithDefaultValues()
         {
-            Assert.False(_viewModel.CloseConfirmationVisible);
             Assert.False(_viewModel.ClassifierOpen);
             Assert.False(_viewModel.CanSendClassification);
         }
@@ -87,16 +86,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _viewModel.CloseClassifier.Execute(null);
 
             Assert.False(_viewModel.ClassifierOpen);
-            Assert.False(_viewModel.CloseConfirmationVisible);
             Assert.False(_viewModel.User.Active);
-        }
-
-        [Fact]
-        private void ShouldToggleCloseConfirmation()
-        {
-            Assert.False(_viewModel.CloseConfirmationVisible);
-            _viewModel.ShowCloseConfirmation.Execute(null);
-            Assert.True(_viewModel.CloseConfirmationVisible);
         }
 
         [Fact]

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/CloseConfirmationViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/CloseConfirmationViewModelTests.cs
@@ -1,0 +1,51 @@
+﻿using GalaxyZooTouchTable.ViewModels;
+using Xunit;
+
+namespace GalaxyZooTouchTable.Tests.ViewModels
+{
+    public class CloseConfirmationViewModelTests
+    {
+        CloseConfirmationViewModel _viewModel = new CloseConfirmationViewModel();
+
+        [Fact]
+        private void ShouldInitializeWithDefaultValues()
+        {
+            Assert.False(_viewModel.Intent);
+            Assert.False(_viewModel.IsVisible);
+        }
+
+        [Fact]
+        private void ShouldCheckIntent()
+        {
+            Assert.False(_viewModel.Intent);
+            _viewModel.CheckIntent.Execute(null);
+            Assert.True(_viewModel.Intent);
+        }
+
+        [Fact]
+        private void ShouldCloseClassifier()
+        {
+            bool EndSessionCalled = false;
+            _viewModel.CheckIntent.Execute(null);
+            _viewModel.EndSession += delegate { EndSessionCalled = true; };
+            _viewModel.CloseClassifier.Execute(null);
+            Assert.True(EndSessionCalled);
+            Assert.False(_viewModel.Intent);
+        }
+
+        [Fact]
+        private void ShouldOpenConfirmationModal()
+        {
+            _viewModel.ToggleCloseConfirmation.Execute(null);
+            Assert.True(_viewModel.IsVisible);
+        }
+
+        [Fact]
+        private void ShouldCloseConfirmationModal()
+        {
+            _viewModel.ToggleCloseConfirmation.Execute(null);
+            _viewModel.ToggleCloseConfirmation.Execute(false);
+            Assert.False(_viewModel.IsVisible);
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/StillThereViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/StillThereViewModelTests.cs
@@ -17,7 +17,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         public void ShouldInitializeWithDefaultValues()
         {
             Assert.Equal(30, _viewModel.CurrentSeconds);
-            Assert.False(_viewModel.Visible);
+            Assert.False(_viewModel.IsVisible);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             var resetFiveMinuteTimerFired = false;
             _viewModel.ResetFiveMinuteTimer += () => resetFiveMinuteTimerFired = true;
             _viewModel.CloseModal.Execute(null);
-            Assert.False(_viewModel.Visible);
+            Assert.False(_viewModel.IsVisible);
             Assert.True(resetFiveMinuteTimerFired);
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/StillThereViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/StillThereViewModelTests.cs
@@ -1,5 +1,4 @@
 ﻿using GalaxyZooTouchTable.ViewModels;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace GalaxyZooTouchTable.Tests.ViewModels

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Services\LocalDBService.cs" />
     <Compile Include="Services\PanoptesService.cs" />
     <Compile Include="ViewModels\CenterpieceViewModel.cs" />
+    <Compile Include="ViewModels\CloseConfirmationViewModel.cs" />
     <Compile Include="ViewModels\NotificationAvatarViewModel.cs" />
     <Compile Include="ViewModels\NotificationsViewModel.cs" />
     <Compile Include="Models\CircularProgress.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -105,13 +105,6 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private bool _closeConfirmationVisible = false;
-        public bool CloseConfirmationVisible
-        {
-            get => _closeConfirmationVisible;
-            set => SetProperty(ref _closeConfirmationVisible, value);
-        }
-
         private bool _classifierOpen = false;
         public bool ClassifierOpen
         {
@@ -185,6 +178,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void AddSubscribers()
         {
+            CloseConfirmationViewModel.EndSession += OnCloseClassifier;
             ExamplesViewModel.PropertyChanged += ResetStillThereModalTimer;
             LevelerViewModel.PropertyChanged += ResetStillThereModalTimer;
             Notifications.PropertyChanged += ResetStillThereModalTimer;
@@ -215,7 +209,12 @@ namespace GalaxyZooTouchTable.ViewModels
             ContinueClassification = new CustomCommand(OnContinueClassification);
             OpenClassifier = new CustomCommand(OnOpenClassifier);
             SelectAnswer = new CustomCommand(OnSelectAnswer);
-            ShowCloseConfirmation = new CustomCommand(ToggleCloseConfirmation);
+            ShowCloseConfirmation = new CustomCommand(OnShowCloseConfirmation);
+        }
+
+        private void OnShowCloseConfirmation(object obj)
+        {
+            CloseConfirmationViewModel.OnToggleCloseConfirmation();
         }
 
         private void OnChooseAnotherGalaxy(object sender)
@@ -257,7 +256,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Notifications.NotifyLeaving();
 
             ClassifierOpen = false;
-            CloseConfirmationVisible = false;
+            CloseConfirmationViewModel.OnToggleCloseConfirmation();
             User.Active = false;
             NotifySpaceView(RingNotifierStatus.IsLeaving);
             CompletedClassifications.Clear();
@@ -268,11 +267,6 @@ namespace GalaxyZooTouchTable.ViewModels
             GetSubjectQueue();
             OnChangeView(ClassifierViewEnum.SubjectView);
             TotalVotes = 0;
-        }
-
-        private void ToggleCloseConfirmation(object sender)
-        {
-            CloseConfirmationVisible = !CloseConfirmationVisible;
         }
 
         public void OnChangeView(ClassifierViewEnum view)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -56,6 +56,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public NotificationsViewModel Notifications { get; private set; }
         public ExamplesPanelViewModel ExamplesViewModel { get; private set; }
+        public CloseConfirmationViewModel CloseConfirmationViewModel { get; private set; }
 
         private LevelerViewModel _levelerViewModel;
         public LevelerViewModel LevelerViewModel
@@ -175,6 +176,7 @@ namespace GalaxyZooTouchTable.ViewModels
             LevelerViewModel = new LevelerViewModel(User);
             Notifications = new NotificationsViewModel(User);
             StillThere = new StillThereViewModel();
+            CloseConfirmationViewModel = new CloseConfirmationViewModel();
 
             LoadCommands();
             AddSubscribers();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -91,7 +91,14 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             get => _currentView;
             set => SetProperty(ref _currentView, value);
-        } 
+        }
+
+        private bool _showOverlay = false;
+        public bool ShowOverlay
+        {
+            get => _showOverlay;
+            set => SetProperty(ref _showOverlay, value);
+        }
 
         private SubjectViewEnum _subjectView = SubjectViewEnum.DragSubject;
         public SubjectViewEnum SubjectView
@@ -99,7 +106,7 @@ namespace GalaxyZooTouchTable.ViewModels
             get => _subjectView;
             set
             {
-                Messenger.Default.Send<SubjectViewEnum>(value, $"{User.Name}_SubjectStatus");
+                Messenger.Default.Send(value, $"{User.Name}_SubjectStatus");
                 AllowSelection = value == SubjectViewEnum.MatchedSubject;
                 SetProperty(ref _subjectView, value);
             }
@@ -182,10 +189,19 @@ namespace GalaxyZooTouchTable.ViewModels
             ExamplesViewModel.PropertyChanged += ResetStillThereModalTimer;
             LevelerViewModel.PropertyChanged += ResetStillThereModalTimer;
             Notifications.PropertyChanged += ResetStillThereModalTimer;
+
             Notifications.GetSubjectById += OnGetSubjectById;
             Notifications.ChangeView += OnChangeView;
             StillThere.ResetFiveMinuteTimer += StartStillThereModalTimer;
             StillThere.CloseClassificationPanel += OnCloseClassifier;
+
+            CloseConfirmationViewModel.CheckOverlay += OnShouldShowOverlay;
+            StillThere.CheckOverlay += OnShouldShowOverlay;
+        }
+
+        private void OnShouldShowOverlay()
+        {
+            ShowOverlay = CloseConfirmationViewModel.IsVisible || StillThere.IsVisible;
         }
 
         public async void Load()
@@ -307,7 +323,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
+            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
             StartStillThereModalTimer();
         }
 
@@ -315,13 +331,13 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             StillThereTimer.Stop();
             StillThereTimer.Start();
-            if (StillThere.Visible) { StillThere.Visible = false; }
+            if (StillThere.IsVisible) { StillThere.IsVisible = false; }
         }
 
         private void ShowStillThereModal(object sender, System.EventArgs e)
         {
             StillThereTimer.Stop();
-            StillThere.Visible = true;
+            StillThere.IsVisible = true;
         }
 
         public void ChooseAnswer(AnswerButton button)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -313,7 +313,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
+            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
             StartStillThereModalTimer();
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -4,7 +4,6 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using GraphQL.Common.Response;
 using PanoptesNetClient.Models;
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -323,7 +322,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
+            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
             StartStillThereModalTimer();
         }
 
@@ -443,7 +442,6 @@ namespace GalaxyZooTouchTable.ViewModels
                     {
                         var index = System.Convert.ToInt32(count.Name);
                         AnswerButton Answer = CurrentAnswers[index];
-
 
                         int answerCount = (int)count.Value;
                         Answer.AnswerCount = answerCount;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -53,9 +53,10 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
+        public CloseConfirmationViewModel CloseConfirmationViewModel { get; private set; } = new CloseConfirmationViewModel();
+        public ExamplesPanelViewModel ExamplesViewModel { get; private set; } = new ExamplesPanelViewModel();
         public NotificationsViewModel Notifications { get; private set; }
-        public ExamplesPanelViewModel ExamplesViewModel { get; private set; }
-        public CloseConfirmationViewModel CloseConfirmationViewModel { get; private set; }
+        public StillThereViewModel StillThere { get; private set; } = new StillThereViewModel();
 
         private LevelerViewModel _levelerViewModel;
         public LevelerViewModel LevelerViewModel
@@ -69,13 +70,6 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             get => _currentAnswers;
             set => SetProperty(ref _currentAnswers, value);
-        }
-
-        private StillThereViewModel _stillThere;
-        public StillThereViewModel StillThere
-        {
-            get => _stillThere;
-            set => SetProperty(ref _stillThere, value);
         }
 
         private int _totalVotes = 0;
@@ -170,12 +164,9 @@ namespace GalaxyZooTouchTable.ViewModels
             _graphQLService = graphQLService;
             _localDBService = localDBService;
             User = user;
-
-            ExamplesViewModel = new ExamplesPanelViewModel();
+            
             LevelerViewModel = new LevelerViewModel(User);
             Notifications = new NotificationsViewModel(User);
-            StillThere = new StillThereViewModel();
-            CloseConfirmationViewModel = new CloseConfirmationViewModel();
 
             LoadCommands();
             AddSubscribers();

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -256,7 +256,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Notifications.NotifyLeaving();
 
             ClassifierOpen = false;
-            CloseConfirmationViewModel.OnToggleCloseConfirmation();
+            CloseConfirmationViewModel.OnToggleCloseConfirmation(false);
             User.Active = false;
             NotifySpaceView(RingNotifierStatus.IsLeaving);
             CompletedClassifications.Clear();
@@ -307,7 +307,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
+            StillThereTimer.Interval = new System.TimeSpan(0, 0, 10);
             StartStillThereModalTimer();
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -1,11 +1,15 @@
 ﻿using GalaxyZooTouchTable.Utility;
+using System;
 using System.Windows.Input;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
     public class CloseConfirmationViewModel : ViewModelBase
     {
-        public ICommand CheckIntent { get; set; }
+        public event Action<object> EndSession = delegate { };
+        public ICommand CloseClassifier { get; private set; }
+        public ICommand CheckIntent { get; private set; }
+        public ICommand ToggleCloseConfirmation { get; private set; }
 
         private bool _intent = false;
         public bool Intent
@@ -14,9 +18,29 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _intent, value);
         }
 
+        private bool _isVisible = false;
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
+
         public CloseConfirmationViewModel()
         {
             CheckIntent = new CustomCommand(OnCheckIntent, CanCheckIntent);
+            CloseClassifier = new CustomCommand(OnCloseClassifier);
+            ToggleCloseConfirmation = new CustomCommand(OnToggleCloseConfirmation);
+        }
+
+        private void OnCloseClassifier(object obj)
+        {
+            Intent = false;
+            EndSession(null);
+        }
+
+        public void OnToggleCloseConfirmation(object sender = null)
+        {
+            IsVisible = !IsVisible;
         }
 
         private bool CanCheckIntent(object obj)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -10,6 +10,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public ICommand CloseClassifier { get; private set; }
         public ICommand CheckIntent { get; private set; }
         public ICommand ToggleCloseConfirmation { get; private set; }
+        public event Action CheckOverlay = delegate { };
 
         private bool _intent = false;
         public bool Intent
@@ -22,7 +23,11 @@ namespace GalaxyZooTouchTable.ViewModels
         public bool IsVisible
         {
             get => _isVisible;
-            set => SetProperty(ref _isVisible, value);
+            set
+            {
+                SetProperty(ref _isVisible, value);
+                CheckOverlay();
+            }
         }
 
         public CloseConfirmationViewModel()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -1,0 +1,32 @@
+﻿using GalaxyZooTouchTable.Utility;
+using System.Windows.Input;
+
+namespace GalaxyZooTouchTable.ViewModels
+{
+    public class CloseConfirmationViewModel : ViewModelBase
+    {
+        public ICommand CheckIntent { get; set; }
+
+        private bool _intent = false;
+        public bool Intent
+        {
+            get => _intent;
+            set => SetProperty(ref _intent, value);
+        }
+
+        public CloseConfirmationViewModel()
+        {
+            CheckIntent = new CustomCommand(OnCheckIntent, CanCheckIntent);
+        }
+
+        private bool CanCheckIntent(object obj)
+        {
+            return !Intent;
+        }
+
+        private void OnCheckIntent(object obj)
+        {
+            Intent = true;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -38,9 +38,10 @@ namespace GalaxyZooTouchTable.ViewModels
             EndSession(null);
         }
 
-        public void OnToggleCloseConfirmation(object sender = null)
+        public void OnToggleCloseConfirmation(object visible = null)
         {
-            IsVisible = !IsVisible;
+            bool? show = visible as bool?;
+            IsVisible = show ?? !IsVisible;
         }
 
         private bool CanCheckIntent(object obj)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -6,11 +6,12 @@ namespace GalaxyZooTouchTable.ViewModels
 {
     public class CloseConfirmationViewModel : ViewModelBase
     {
+        public event Action CheckOverlay = delegate { };
         public event Action<object> EndSession = delegate { };
+
         public ICommand CloseClassifier { get; private set; }
         public ICommand CheckIntent { get; private set; }
         public ICommand ToggleCloseConfirmation { get; private set; }
-        public event Action CheckOverlay = delegate { };
 
         private bool _intent;
         public bool Intent

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -12,14 +12,14 @@ namespace GalaxyZooTouchTable.ViewModels
         public ICommand ToggleCloseConfirmation { get; private set; }
         public event Action CheckOverlay = delegate { };
 
-        private bool _intent = false;
+        private bool _intent;
         public bool Intent
         {
             get => _intent;
             set => SetProperty(ref _intent, value);
         }
 
-        private bool _isVisible = false;
+        private bool _isVisible;
         public bool IsVisible
         {
             get => _isVisible;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/StillThereViewModel.cs
@@ -13,6 +13,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public event Action<object> CloseClassificationPanel = delegate { };
         public event Action ResetFiveMinuteTimer = delegate { };
         private int Percentage { get; set; } = 100;
+        public event Action CheckOverlay = delegate { };
 
         public ICommand CloseClassifier { get; set; }
         public ICommand CloseModal { get; set; }
@@ -31,10 +32,10 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _currentSeconds, value);
         }
 
-        private bool _visible = false;
-        public bool Visible
+        private bool _isVisible = false;
+        public bool IsVisible
         {
-            get => _visible;
+            get => _isVisible;
             set
             {
                 if (value == true)
@@ -44,7 +45,8 @@ namespace GalaxyZooTouchTable.ViewModels
                 {
                     SecondTimer.Stop();
                 }
-                SetProperty(ref _visible, value);
+                SetProperty(ref _isVisible, value);
+                CheckOverlay();
             }
         }
 
@@ -76,7 +78,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnCloseModal(object sender)
         {
-            Visible = false;
+            IsVisible = false;
             ResetFiveMinuteTimer();
         }
 
@@ -107,7 +109,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentSeconds == 0)
             {
                 CloseClassificationPanel(null);
-                Visible = false;
+                IsVisible = false;
             }
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -120,7 +120,7 @@
             <Grid.Background>
                 <SolidColorBrush Color="#343438" Opacity="0.9"/>
             </Grid.Background>
-            <local:CloseConfirmation Width="243" Height="200"/>
+            <local:CloseConfirmation Width="243" Height="200" DataContext="{Binding CloseConfirmationViewModel}"/>
         </Grid>
         
         <local:ExamplesPanel

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -46,11 +46,16 @@
 
         <Views:StillThereModal
             DataContext="{Binding StillThere}"
-            Margin="108,2,0,0"
+            Margin="108,20,128,0"
             Visibility="{Binding Visible, Converter={StaticResource BoolToVis}, FallbackValue=Hidden}"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Bottom"
-            Panel.ZIndex="1"/>
+            Panel.ZIndex="2"/>
+
+        <local:CloseConfirmation
+            Panel.ZIndex="1"
+            Margin="108,20,128,0"
+            Width="243"
+            Height="200"
+            DataContext="{Binding CloseConfirmationViewModel}"/>
 
         <Border
             Background="{StaticResource DarkGrayColor}"
@@ -113,15 +118,6 @@
             </Grid>
         </Border>
 
-        <Grid
-            Margin="108,20,128,0"
-            Panel.ZIndex="1">
-            <!--<Grid.Background>
-                <SolidColorBrush Color="#343438" Opacity="0.9"/>
-            </Grid.Background>-->
-            <local:CloseConfirmation Width="243" Height="200" DataContext="{Binding CloseConfirmationViewModel}"/>
-        </Grid>
-        
         <local:ExamplesPanel
             Panel.ZIndex="-1"
             DataContext="{Binding ExamplesViewModel}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -46,15 +46,13 @@
 
         <Views:StillThereModal
             DataContext="{Binding StillThere}"
-            Margin="108,20,128,0"
-            Panel.ZIndex="2"/>
+            Panel.ZIndex="2"
+            Margin="108,20,128,0"/>
 
         <local:CloseConfirmation
+            DataContext="{Binding CloseConfirmationViewModel}"
             Panel.ZIndex="1"
-            Margin="108,20,128,0"
-            Width="243"
-            Height="200"
-            DataContext="{Binding CloseConfirmationViewModel}"/>
+            Margin="108,20,128,0"/>
 
         <Border
             Background="{StaticResource DarkGrayColor}"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -47,7 +47,6 @@
         <Views:StillThereModal
             DataContext="{Binding StillThere}"
             Margin="108,20,128,0"
-            Visibility="{Binding Visible, Converter={StaticResource BoolToVis}, FallbackValue=Hidden}"
             Panel.ZIndex="2"/>
 
         <local:CloseConfirmation
@@ -68,8 +67,16 @@
             <Border.Effect>
                 <DropShadowEffect Color="Black" BlurRadius="20" ShadowDepth="0"/>
             </Border.Effect>
-
+            
             <Grid Background="Transparent">
+                <Border
+                    Background="#F2343438"
+                    CornerRadius="{Binding Path=CornerRadius, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Border}}}"
+                    Width="{Binding Path=ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Border}}}"
+                    Height="{Binding Path=ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Border}}}"
+                    Visibility="{Binding ShowOverlay, Converter={StaticResource BoolToVis}, FallbackValue=Collapsed}"
+                    Panel.ZIndex="1"/>
+                
                 <StackPanel
                     Background="{StaticResource DarkGrayColor}"
                     HorizontalAlignment="Right"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -115,11 +115,10 @@
 
         <Grid
             Margin="108,20,128,0"
-            Panel.ZIndex="1"
-            Visibility="{Binding CloseConfirmationVisible, Converter={StaticResource BoolToVis}, FallbackValue=Hidden}">
-            <Grid.Background>
+            Panel.ZIndex="1">
+            <!--<Grid.Background>
                 <SolidColorBrush Color="#343438" Opacity="0.9"/>
-            </Grid.Background>
+            </Grid.Background>-->
             <local:CloseConfirmation Width="243" Height="200" DataContext="{Binding CloseConfirmationViewModel}"/>
         </Grid>
         

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
@@ -34,13 +34,13 @@
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
-    
-    <Border Style="{StaticResource CloseConfirmation}" CornerRadius="5" Background="{StaticResource MedGrayColor}">
+
+    <Border Style="{StaticResource CloseConfirmation}" Height="199" Width="243" CornerRadius="3" Background="{StaticResource MedGrayColor}">
         <Border.Effect>
             <DropShadowEffect BlurRadius="20" ShadowDepth="2"/>
         </Border.Effect>
 
-        <Grid Width="243" Height="199">
+        <Grid>
             <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
                 <i:Interaction.Behaviors>
                     <Behaviors:TapBehavior Command="{Binding ToggleCloseConfirmation}"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
@@ -82,6 +82,19 @@
                 VerticalAlignment="Bottom"
                 Width="57"/>
 
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="15,0,0,42">
+                <Border BorderBrush="#171718" Width="12" Height="12" CornerRadius="2" BorderThickness="1"/>
+                <TextBlock
+                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                    VerticalAlignment="Center"
+                    Margin="4,0,0,0"
+                    FontStyle="Italic"
+                    FontSize="7"
+                    Foreground="#FFFFFF">
+                    Yes, I'll check it out online
+                </TextBlock>
+            </StackPanel> 
+            
             <local:MultiTouchButton
                 Style="{StaticResource TransparentWithDownstate}"
                 Height="20"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
@@ -15,6 +15,14 @@
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
+
+        <Style x:Key="CheckBox" TargetType="{x:Type Border}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Intent}" Value="True">
+                    <Setter Property="Background" Value="#E5FF4D" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
     
     <Border CornerRadius="5" Background="{StaticResource MedGrayColor}">
@@ -83,7 +91,10 @@
                 Width="57"/>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="15,0,0,42">
-                <Border BorderBrush="#171718" Width="12" Height="12" CornerRadius="2" BorderThickness="1"/>
+                <i:Interaction.Behaviors>
+                    <Behaviors:TapBehavior Command="{Binding CheckIntent}"/>
+                </i:Interaction.Behaviors>
+                <Border Style="{StaticResource CheckBox}" BorderBrush="#171718" Width="12" Height="12" CornerRadius="2" BorderThickness="1"/>
                 <TextBlock
                     FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
                     VerticalAlignment="Center"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
@@ -23,9 +23,19 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
+
+        <Style x:Key="CloseConfirmation" TargetType="{x:Type Border}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsVisible}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
     
-    <Border CornerRadius="5" Background="{StaticResource MedGrayColor}">
+    <Border Style="{StaticResource CloseConfirmation}" CornerRadius="5" Background="{StaticResource MedGrayColor}">
         <Border.Effect>
             <DropShadowEffect BlurRadius="20" ShadowDepth="2"/>
         </Border.Effect>
@@ -33,7 +43,7 @@
         <Grid Width="243" Height="199">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding ShowCloseConfirmation}"/>
+                    <Behaviors:TapBehavior Command="{Binding ToggleCloseConfirmation}"/>
                 </i:Interaction.Behaviors>
                 <TextBlock
                     Style="{StaticResource CommonType}"
@@ -113,7 +123,7 @@
                 Margin="15,0,0,14"
                 VerticalAlignment="Bottom"
                 Width="104"
-                PressCommand="{Binding ShowCloseConfirmation}">
+                PressCommand="{Binding ToggleCloseConfirmation}">
                 <TextBlock
                     Style="{StaticResource CommonType}"
                     FontSize="10"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -16,9 +16,18 @@
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
+
+        <Style x:Key="MainBorder" TargetType="Border">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsVisible}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
 
-    <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
+    <Border Style="{StaticResource MainBorder}" Height="199" Width="243" Background="#55565A" CornerRadius="3">
         <Grid>
             <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -27,7 +27,11 @@
         </Style>
     </UserControl.Resources>
 
-    <Border Style="{StaticResource MainBorder}" Height="199" Width="243" Background="#55565A" CornerRadius="3">
+    <Border Style="{StaticResource MainBorder}" Height="199" Width="243" CornerRadius="3" Background="{StaticResource MedGrayColor}">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="20" ShadowDepth="2"/>
+        </Border.Effect>
+
         <Grid>
             <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/StillThereModal.xaml
@@ -8,7 +8,7 @@
              xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
              xmlns:local="clr-namespace:GalaxyZooTouchTable.Views"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="199" d:DesignWidth="243">
 
     <UserControl.Resources>
         <Style x:Key="CommonType" TargetType="{x:Type TextBlock}">
@@ -18,113 +18,111 @@
         </Style>
     </UserControl.Resources>
 
-    <Border CornerRadius="3" Height="291" Width="312" Background="#F2343438">
-        <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
-            <Grid>
-                <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
+    <Border Height="199" Width="243" Background="#55565A" CornerRadius="3">
+        <Grid>
+            <Image Source="../Images/General/Logo.png" Height="14" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15,10,0,0"/>
 
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
-                    <i:Interaction.Behaviors>
-                        <Behaviors:TapBehavior Command="{Binding CloseModal}"/>
-                    </i:Interaction.Behaviors>
-                    <TextBlock
-                        FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                        FontSize="10"
-                        Foreground="White"
-                        Margin="5,0"
-                        Text="Cancel"/>
-                    <fa:ImageAwesome
-                        Foreground="White"
-                        Height="8.5"
-                        Icon="Times"/>
-                </StackPanel>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
+                <i:Interaction.Behaviors>
+                    <Behaviors:TapBehavior Command="{Binding CloseModal}"/>
+                </i:Interaction.Behaviors>
+                <TextBlock
+                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                    FontSize="10"
+                    Foreground="White"
+                    Margin="5,0"
+                    Text="Cancel"/>
+                <fa:ImageAwesome
+                    Foreground="White"
+                    Height="8.5"
+                    Icon="Times"/>
+            </StackPanel>
 
-                <Separator
-                    VerticalAlignment="Top"
-                    Width="212"
-                    Margin="0,29,0,0"
-                    Background="{StaticResource DarkGrayColor}"/>
+            <Separator
+                VerticalAlignment="Top"
+                Width="212"
+                Margin="0,29,0,0"
+                Background="{StaticResource DarkGrayColor}"/>
 
+            <TextBlock
+                Style="{StaticResource CommonType}"
+                Text="Still there?"
+                Margin="16,43.9,0,0"
+                FontSize="19"/>
+
+            <local:MultiTouchButton
+                Style="{StaticResource TransparentWithDownstate}"
+                Height="20"
+                HorizontalAlignment="Left"
+                Margin="15,0,0,14"
+                VerticalAlignment="Bottom"
+                Width="104"
+                PressCommand="{Binding CloseClassifier}">
                 <TextBlock
                     Style="{StaticResource CommonType}"
-                    Text="Still there?"
-                    Margin="16,43.9,0,0"
-                    FontSize="19"/>
+                    FontSize="10"
+                    HorizontalAlignment="Center"
+                    Text="Close now"
+                    VerticalAlignment="Center"/>
+            </local:MultiTouchButton>
 
+            <local:MultiTouchButton
+                Style="{StaticResource SubmitWithDownstate}"
+                Height="20"
+                HorizontalAlignment="Right"
+                Margin="0,0,15.3,14.59"
+                VerticalAlignment="Bottom"
+                Width="104"
+                PressCommand="{Binding CloseModal}">
                 <TextBlock
-                    Text="Tap &quot;Still working&quot; before the countdown runs out or this workspace will be closed"
-                    Foreground="White"
-                    Margin="16,69.4,0,0"
-                    FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                    Width="94"
-                    Height="86"
-                    VerticalAlignment="Top"
-                    HorizontalAlignment="Left"
-                    TextWrapping="Wrap"
-                    FontSize="9"/>
+                    Style="{StaticResource CommonType}"
+                    FontSize="10"
+                    Foreground="Black"
+                    HorizontalAlignment="Center"
+                    Text="Still working"
+                    VerticalAlignment="Center"/>
+            </local:MultiTouchButton>
+            
+            <TextBlock
+                Text="Tap &quot;Still working&quot; before the countdown runs out or this workspace will be closed"
+                Foreground="White"
+                Margin="16,69.4,0,0"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                Width="94"
+                Height="86"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Left"
+                TextWrapping="Wrap"
+                FontSize="9"/>
 
-                <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
-                    <Path Width="90" Height="90" Stroke="#E5FF4D" StrokeThickness="8">
-                        <Path.Data>
-                            <PathGeometry>
-                                <PathGeometry.Figures>
-                                    <PathFigureCollection>
-                                        <PathFigure StartPoint="{Binding Circle.StartPoint}">
-                                            <PathFigure.Segments>
-                                                <PathSegmentCollection>
-                                                    <ArcSegment
-                                                        Point="{Binding Circle.ArcPoint}"
-                                                        Size="{Binding Circle.ArcSize}"
-                                                        IsLargeArc="{Binding Circle.IsLargeArc}"
-                                                        SweepDirection="CounterClockwise" />
-                                                </PathSegmentCollection>
-                                            </PathFigure.Segments>
-                                        </PathFigure>
-                                    </PathFigureCollection>
-                                </PathGeometry.Figures>
-                            </PathGeometry>
-                        </Path.Data>
-                    </Path>
-                </Grid>
-
-                <TextBlock Margin="160,74,0,0" FontSize="26" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Poppins" Foreground="White" FontWeight="Bold">
-                    <Run>:</Run>
-                    <Run Text="{Binding CurrentSeconds, Mode=OneWay}"/>
-                </TextBlock>
-
-                <local:MultiTouchButton
-                    Style="{StaticResource TransparentWithDownstate}"
-                    Height="20"
-                    HorizontalAlignment="Left"
-                    Margin="15,0,0,14"
-                    VerticalAlignment="Bottom"
-                    Width="104"
-                    PressCommand="{Binding CloseClassifier}">
-                    <TextBlock
-                        Style="{StaticResource CommonType}"
-                        FontSize="10"
-                        HorizontalAlignment="Center"
-                        Text="Close now"
-                        VerticalAlignment="Center"/>
-                </local:MultiTouchButton>
-
-                <local:MultiTouchButton
-                    Style="{StaticResource SubmitWithDownstate}"
-                    Height="20"
-                    HorizontalAlignment="Right"
-                    Margin="0,0,15.3,14.59"
-                    VerticalAlignment="Bottom"
-                    Width="104"
-                    PressCommand="{Binding CloseModal}">
-                    <TextBlock
-                        Style="{StaticResource CommonType}"
-                        FontSize="10"
-                        Foreground="Black"
-                        HorizontalAlignment="Center"
-                        Text="Still working"
-                        VerticalAlignment="Center"/>
-                </local:MultiTouchButton>
+            <Grid Margin="134,50,0,0" Height="100" Width="100" VerticalAlignment="Top">
+                <Path Width="90" Height="90" Stroke="#E5FF4D" StrokeThickness="8">
+                    <Path.Data>
+                        <PathGeometry>
+                            <PathGeometry.Figures>
+                                <PathFigureCollection>
+                                    <PathFigure StartPoint="{Binding Circle.StartPoint}">
+                                        <PathFigure.Segments>
+                                            <PathSegmentCollection>
+                                                <ArcSegment
+                                                    Point="{Binding Circle.ArcPoint}"
+                                                    Size="{Binding Circle.ArcSize}"
+                                                    IsLargeArc="{Binding Circle.IsLargeArc}"
+                                                    SweepDirection="CounterClockwise" />
+                                            </PathSegmentCollection>
+                                        </PathFigure.Segments>
+                                    </PathFigure>
+                                </PathFigureCollection>
+                            </PathGeometry.Figures>
+                        </PathGeometry>
+                    </Path.Data>
+                </Path>
             </Grid>
-        </Border>
+
+            <TextBlock Margin="160,74,0,0" FontSize="26" FontFamily="/GalaxyZooTouchTable;component/Fonts/#Poppins" Foreground="White" FontWeight="Bold">
+                <Run>:</Run>
+                <Run Text="{Binding CurrentSeconds, Mode=OneWay}"/>
+            </TextBlock>
+        </Grid>
     </Border>
 </UserControl>


### PR DESCRIPTION
Describe your changes.
This PR adds the "intent" button to the close classifier modal. Eventually, button presses will be tracked, likely through GA. Other code changes include:

- Creating a `CloseConfirmationViewModel` to abstract code away from the classifier
- Create a `ShowOverlay` property on the classifier to keep two gray background overlays from populating on top of one another, which can occur when the StillThere and CloseConfirmation modals appear at the same time.

Closes #64.

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
