### PR TITLE
Use secondary cutout

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -49,7 +49,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
                 _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(SpaceNavigationMockData.Center());
                 _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>()))
                     .Returns(new List<TableSubject>());
-                _cutoutServiceMock.Setup(dp => dp.GetSpaceCutout(It.IsAny<SpaceNavigation>())).ReturnsAsync(new System.Windows.Media.Imaging.BitmapImage());
+                _cutoutServiceMock.Setup(dp => dp.GetSpaceCutout(It.IsAny<SpaceNavigation>())).ReturnsAsync(new Lib.SpaceCutout());
 
                 _viewModel = new SpaceViewModel(_localDBServiceMock.Object, _cutoutServiceMock.Object);
             }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -215,7 +215,6 @@
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Lib\PeripheralItems.cs" />
     <Compile Include="Lib\RingNotifierStatus.cs" />
-    <Compile Include="Lib\TableSubjects.cs" />
     <Compile Include="Lib\WorkspacePositions.cs" />
     <Compile Include="Models\ClassificationCounts.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />
@@ -233,7 +232,6 @@
     <Compile Include="Models\PendingRequest.cs" />
     <Compile Include="Services\CutoutService.cs" />
     <Compile Include="Services\GraphQLService.cs" />
-    <Compile Include="Services\ICutoutService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
     <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -229,7 +229,9 @@
     <Compile Include="Models\SpaceNavigation.cs" />
     <Compile Include="Models\SpacePoint.cs" />
     <Compile Include="Models\PendingRequest.cs" />
+    <Compile Include="Services\CutoutService.cs" />
     <Compile Include="Services\GraphQLService.cs" />
+    <Compile Include="Services\ICutoutService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
     <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Models\PendingRequest.cs" />
     <Compile Include="Services\CutoutService.cs" />
     <Compile Include="Services\GraphQLService.cs" />
+    <Compile Include="Services\ICutoutService.cs" />
     <Compile Include="Services\IGraphQLService.cs" />
     <Compile Include="Services\ILocalDBService.cs" />
     <Compile Include="Services\IPanoptesService.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -213,7 +213,9 @@
     <Compile Include="Lib\Log.cs" />
     <Compile Include="Lib\NotificationPanelStatus.cs" />
     <Compile Include="Lib\Messenger.cs" />
+    <Compile Include="Lib\PeripheralItems.cs" />
     <Compile Include="Lib\RingNotifierStatus.cs" />
+    <Compile Include="Lib\TableSubjects.cs" />
     <Compile Include="Lib\WorkspacePositions.cs" />
     <Compile Include="Models\ClassificationCounts.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Lib\Messenger.cs" />
     <Compile Include="Lib\PeripheralItems.cs" />
     <Compile Include="Lib\RingNotifierStatus.cs" />
+    <Compile Include="Lib\SpaceCutout.cs" />
     <Compile Include="Lib\WorkspacePositions.cs" />
     <Compile Include="Models\ClassificationCounts.cs" />
     <Compile Include="Models\ClassificationPanelViewModelFactory.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/PeripheralItems.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/PeripheralItems.cs
@@ -1,6 +1,5 @@
 ﻿using GalaxyZooTouchTable.Models;
 using System.Collections.Generic;
-using System.Windows.Media.Imaging;
 
 namespace GalaxyZooTouchTable.Lib
 {
@@ -14,7 +13,7 @@ namespace GalaxyZooTouchTable.Lib
 
     public class PeripheralItem
     {
-        public BitmapImage Cutout { get; set; }
+        public SpaceCutout Cutout { get; set; }
         public SpaceNavigation Location { get; set; }
         public List<TableSubject> Galaxies { get; set; }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/PeripheralItems.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/PeripheralItems.cs
@@ -1,0 +1,23 @@
+﻿using GalaxyZooTouchTable.Models;
+using System.Collections.Generic;
+using System.Windows.Media.Imaging;
+
+namespace GalaxyZooTouchTable.Lib
+{
+    public class PeripheralItems
+    {
+        public PeripheralItem Northern { get; set; }
+        public PeripheralItem Southern { get; set; }
+        public PeripheralItem Eastern { get; set; }
+        public PeripheralItem Western { get; set; }
+    }
+
+    public class PeripheralItem
+    {
+        public BitmapImage Cutout { get; set; }
+        public SpaceNavigation Location { get; set; }
+        public List<TableSubject> Galaxies { get; set; }
+
+        public PeripheralItem(SpaceNavigation location) { Location = location; }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/SpaceCutout.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/SpaceCutout.cs
@@ -4,8 +4,6 @@ namespace GalaxyZooTouchTable.Lib
 {
     public class SpaceCutout
     {
-        public bool IsSDSS;
-        public bool IsDECALS;
         public BitmapImage ImageOne { get; set; }
         public BitmapImage ImageTwo { get; set; }
         public BitmapImage ImageThree { get; set; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/SpaceCutout.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/SpaceCutout.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows.Media.Imaging;
+
+namespace GalaxyZooTouchTable.Lib
+{
+    public class SpaceCutout
+    {
+        public bool IsSDSS;
+        public bool IsDECALS;
+        public BitmapImage ImageOne { get; set; }
+        public BitmapImage ImageTwo { get; set; }
+        public BitmapImage ImageThree { get; set; }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/TableSubjects.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/TableSubjects.cs
@@ -1,0 +1,6 @@
+﻿namespace GalaxyZooTouchTable.Lib
+{
+    internal class TableSubjects
+    {
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/TableSubjects.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/TableSubjects.cs
@@ -1,6 +1,0 @@
-﻿namespace GalaxyZooTouchTable.Lib
-{
-    internal class TableSubjects
-    {
-    }
-}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -49,28 +49,24 @@
             return (Degrees * System.Math.PI) / 180.0;
         }
 
-        public void MoveNorth()
+        public SpacePoint NextNorthernPoint()
         {
-            Center.Declination += DecRange;
-            UpdateBounds();
+            return new SpacePoint(Center.RightAscension, Center.Declination + DecRange);
         }
 
-        public void MoveSouth()
+        public SpacePoint NextSouthernPoint()
         {
-            Center.Declination -= DecRange;
-            UpdateBounds();
+            return new SpacePoint(Center.RightAscension, Center.Declination - DecRange);
         }
 
-        public void MoveEast()
+        public SpacePoint NextEasternPoint()
         {
-            Center.RightAscension -= RaRangeFunc();
-            UpdateBounds();
+            return new SpacePoint(Center.RightAscension - RaRangeFunc(), Center.Declination);
         }
 
-        public void MoveWest()
+        public SpacePoint NextWesternPoint()
         {
-            Center.RightAscension += RaRangeFunc();
-            UpdateBounds();
+            return new SpacePoint(Center.RightAscension + RaRangeFunc(), Center.Declination);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/SpaceNavigation.cs
@@ -7,6 +7,7 @@
         const int CutoutHeight = 432;
         const int ArcDegreeInSeconds = 3600;
         public double DecRange { get; set; } = CutoutHeight * PlateScale / ArcDegreeInSeconds;
+        public double RaRange { get; set; }
         public double MinRa { get; set; }
         public double MaxRa { get; set; }
         public double MinDec { get; set; }
@@ -29,15 +30,16 @@
             UpdateBounds();
         }
 
-        public double RaRange()
+        public double RaRangeFunc()
         {
-            return (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(Center.Declination))));
+            RaRange = (CutoutWidth * PlateScale / ArcDegreeInSeconds) / System.Math.Abs(System.Math.Cos((ToRadians(Center.Declination))));
+            return RaRange;
         }
 
         private void UpdateBounds()
         {
-            MinRa = Center.RightAscension - (RaRange() / 2);
-            MaxRa = Center.RightAscension + (RaRange() / 2);
+            MinRa = Center.RightAscension - (RaRangeFunc() / 2);
+            MaxRa = Center.RightAscension + (RaRangeFunc() / 2);
             MinDec = Center.Declination - (DecRange / 2);
             MaxDec = Center.Declination + (DecRange / 2);
         }
@@ -61,13 +63,13 @@
 
         public void MoveEast()
         {
-            Center.RightAscension -= RaRange();
+            Center.RightAscension -= RaRangeFunc();
             UpdateBounds();
         }
 
         public void MoveWest()
         {
-            Center.RightAscension += RaRange();
+            Center.RightAscension += RaRangeFunc();
             UpdateBounds();
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -12,7 +12,7 @@ using System.Windows.Threading;
 
 namespace GalaxyZooTouchTable.Services
 {
-    public class CutoutService
+    public class CutoutService : ICutoutService
     {
         readonly TimeSpan TimeUntilReset = new TimeSpan(0, 10, 0);
         bool SDSSIsResponding { get; set; } = true;
@@ -118,8 +118,8 @@ namespace GalaxyZooTouchTable.Services
 
         async Task<BitmapImage> StitchImagesTogether(SpaceNavigation currentLocation, double plateScale)
         {
-            //TODO: Remove 0.05 constant below when finding cutouts directly aside one another
-            double RaStep = (currentLocation.RaRange / 3) + (currentLocation.RaRange * 0.05);
+            //TODO: Remove 0.049 constant below when finding cutouts directly aside one another
+            double RaStep = (currentLocation.RaRange / 3) + (currentLocation.RaRange * 0.049);
             double RightImageCenterRa = currentLocation.Center.RightAscension - RaStep;
             double LeftImageCenterRa = currentLocation.Center.RightAscension + RaStep;
             double[] imageRAs = { LeftImageCenterRa, currentLocation.Center.RightAscension, RightImageCenterRa };

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -1,48 +1,68 @@
 ﻿using System;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace GalaxyZooTouchTable.Services
 {
     public class CutoutService : ICutoutService
     {
-        bool FetchDECALSCutout(double ra, double dec, double plateScale)
-        {
-            bool isSuccessfulResponse = false;
+        bool SDSSIsResponding { get; set; } = true;
+        bool DECALSIsResponding { get; set; } = true;
 
+        async Task<WebResponse> FetchDECALSCutout(double ra, double dec, double plateScale)
+        {
+            WebResponse response;
             try
             {
                 string url = $"http://legacysurvey.org/viewer-dev/jpeg-cutout/?ra={ra}&dec={dec}&pixscale={plateScale}&layer=decals-dr7&size=432";
-                var request = (HttpWebRequest)WebRequest.Create(url);
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                isSuccessfulResponse = response.StatusCode == HttpStatusCode.OK;
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+                request.Timeout = 1000;
+                response = await request.GetResponseAsync();
             }
-            catch (Exception e)
+            catch (WebException e)
             {
                 Console.WriteLine(e);
+                response = (HttpWebResponse)e.Response;
+                DECALSIsResponding = false;
             }
-            return isSuccessfulResponse;
+            return response;
         }
 
-        bool FetchSDSSCutout(double ra, double dec, double plateScale)
+        async Task<WebResponse> FetchSDSSCutout(double ra, double dec, double plateScale)
         {
-            bool isSuccessfulResponse = false;
+            WebResponse response;
             try
             {
                 string url = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={ra}&dec={dec}&width=1248&height=432&scale={plateScale}";
-                var request = (HttpWebRequest)WebRequest.Create(url);
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                isSuccessfulResponse = response.StatusCode == HttpStatusCode.OK;
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+                request.Timeout = 1000;
+                response = await request.GetResponseAsync();
             }
-            catch (Exception e)
+            catch (WebException e)
             {
                 Console.WriteLine(e);
+                response = (HttpWebResponse)e.Response;
+                SDSSIsResponding = false;
             }
-            return isSuccessfulResponse;
+            return response;
         }
 
-        public bool GetSpaceCutout(double ra, double dec, double plateScale)
+        public async Task<string> GetSpaceCutout(double ra, double dec, double plateScale)
         {
-            return FetchSDSSCutout(ra, dec, plateScale);
+            string successfulResponse = null;
+            if (SDSSIsResponding)
+            {
+                using (WebResponse response = await FetchSDSSCutout(ra, dec, plateScale))
+                    if (response != null)
+                        successfulResponse = response.ResponseUri.ToString();
+            }
+            if (DECALSIsResponding && successfulResponse == null)
+            {
+                using (WebResponse response = await FetchDECALSCutout(ra, dec, plateScale))
+                    if (response != null)
+                        successfulResponse = response.ResponseUri.ToString();
+            }
+            return successfulResponse;
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -96,7 +96,10 @@ namespace GalaxyZooTouchTable.Services
             //{
             //    using (WebResponse response = await FetchSDSSCutout(ra, dec, plateScale))
             //        if (response != null)
-            //            successfulResponse = response.ResponseUri.ToString();
+            //        {
+            //            string url = response.ResponseUri.ToString();
+            //            image = BitmapFromUrl(url);
+            //        }
             //}
             if (DECALSIsResponding && image == null)
             {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -1,11 +1,18 @@
-﻿using System;
+﻿using GalaxyZooTouchTable.Models;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using System.Windows.Documents;
+using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 
 namespace GalaxyZooTouchTable.Services
 {
-    public class CutoutService : ICutoutService
+    public class CutoutService
     {
         readonly TimeSpan TimeUntilReset = new TimeSpan(0, 10, 0);
         bool SDSSIsResponding { get; set; } = true;
@@ -58,7 +65,7 @@ namespace GalaxyZooTouchTable.Services
             catch (WebException e)
             {
                 Console.WriteLine($"Unable to Connect to DECALS: {e.Message}");
-                DECALSIsResponding = false;
+                TemporarilyDisableDECALS();
             }
             return response;
         }
@@ -81,22 +88,113 @@ namespace GalaxyZooTouchTable.Services
             return response;
         }
 
-        public async Task<string> GetSpaceCutout(double ra, double dec, double plateScale)
+        public async Task<BitmapImage> GetSpaceCutout(double ra, double dec, double plateScale, SpaceNavigation currentLocation)
         {
-            string successfulResponse = null;
-            if (SDSSIsResponding)
-            {
-                using (WebResponse response = await FetchSDSSCutout(ra, dec, plateScale))
-                    if (response != null)
-                        successfulResponse = response.ResponseUri.ToString();
-            }
-            if (DECALSIsResponding && successfulResponse == null)
+            BitmapImage image = null;
+            //if (SDSSIsResponding)
+            //{
+            //    using (WebResponse response = await FetchSDSSCutout(ra, dec, plateScale))
+            //        if (response != null)
+            //            successfulResponse = response.ResponseUri.ToString();
+            //}
+            if (DECALSIsResponding && image == null)
             {
                 using (WebResponse response = await FetchDECALSCutout(ra, dec, plateScale))
                     if (response != null)
-                        successfulResponse = response.ResponseUri.ToString();
+                    {
+                        string url = response.ResponseUri.ToString();
+                        image = BitmapFromUrl(url);
+                    }
             }
-            return successfulResponse;
+            //return CreateImage(successfulResponse);
+            return image;
+        }
+
+        BitmapImage BitmapFromUrl(string url)
+        {
+            BitmapImage image = new BitmapImage();
+            image.BeginInit();
+            image.UriSource = new Uri(url);
+            image.EndInit();
+            return image;
+        }
+
+        //BitmapImage StitchImagesTogether(SpaceNavigation currentLocation, double plateScale)
+        //{
+        //    double RaStep = (currentLocation.RaRange / 3);
+        //    double RightImageCenterRa = currentLocation.Center.RightAscension - RaStep;
+        //    double LeftImageCenterRa = currentLocation.Center.RightAscension + RaStep;
+        //    double[] imageRAs = { LeftImageCenterRa, currentLocation.Center.RightAscension, RightImageCenterRa };
+        //    List<string> urls = new List<string>();
+
+        //    foreach (double ra in imageRAs)
+        //    {
+        //        string url = $"http://legacysurvey.org/viewer-dev/jpeg-cutout/?ra={ra}&dec={currentLocation.Center.Declination}&pixscale={plateScale}&layer=decals-dr7&size=432";
+        //        urls.Add(url);
+        //    }
+        //    List<Bitmap> Bitmaps = ConvertUrlsToBitmaps(urls);
+
+        //    var finalBitmap = new Bitmap(1248, 432);
+        //    using (var g = Graphics.FromImage(finalBitmap))
+        //    {
+        //        int index = 0;
+        //        foreach (var image in Bitmaps)
+        //        {
+        //            g.DrawImage(image, 0, 0);
+        //        }
+        //    }
+        //    return ToBitmapImage(finalBitmap);
+        //}
+
+        BitmapImage ToBitmapImage(Bitmap bitmap)
+        {
+            using (var memory = new MemoryStream())
+            {
+                bitmap.Save(memory, ImageFormat.Png);
+                memory.Position = 0;
+
+                var bitmapImage = new BitmapImage();
+                bitmapImage.BeginInit();
+                bitmapImage.StreamSource = memory;
+                bitmapImage.CacheOption = BitmapCacheOption.OnLoad;
+                bitmapImage.EndInit();
+                return bitmapImage;
+            }
+        }
+
+        Bitmap ConvertUrlToBitmap(string url)
+        {
+            WebClient wc = new WebClient();
+            byte[] bytes = wc.DownloadData(url);
+            using (var ms = new MemoryStream(bytes))
+            {
+                return new Bitmap(ms);
+            }
+        }
+
+        private static List<Bitmap> ConvertUrlsToBitmaps(List<string> imageUrls, WebProxy proxy = null)
+        {
+            List<Bitmap> bitmapList = new List<Bitmap>();
+            foreach (string imgUrl in imageUrls)
+            {
+                try
+                {
+                    WebClient wc = new WebClient();
+                    // If proxy setting then set 
+                    if (proxy != null)
+                        wc.Proxy = proxy;
+                    // Download image 
+                    byte[] bytes = wc.DownloadData(imgUrl);
+                    MemoryStream ms = new MemoryStream(bytes);
+                    Image img = Image.FromStream(ms);
+                    bitmapList.Add((Bitmap)img);
+                }
+                catch (Exception ex)
+                {
+                    Console.Write(ex.Message);
+                }
+            }
+            return bitmapList;
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net;
+
+namespace GalaxyZooTouchTable.Services
+{
+    public class CutoutService : ICutoutService
+    {
+        bool FetchDECALSCutout(double ra, double dec, double plateScale)
+        {
+            bool isSuccessfulResponse = false;
+
+            try
+            {
+                string url = $"http://legacysurvey.org/viewer-dev/jpeg-cutout/?ra={ra}&dec={dec}&pixscale={plateScale}&layer=decals-dr7&size=432";
+                var request = (HttpWebRequest)WebRequest.Create(url);
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                isSuccessfulResponse = response.StatusCode == HttpStatusCode.OK;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            return isSuccessfulResponse;
+        }
+
+        bool FetchSDSSCutout(double ra, double dec, double plateScale)
+        {
+            bool isSuccessfulResponse = false;
+            try
+            {
+                string url = $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={ra}&dec={dec}&width=1248&height=432&scale={plateScale}";
+                var request = (HttpWebRequest)WebRequest.Create(url);
+                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+                isSuccessfulResponse = response.StatusCode == HttpStatusCode.OK;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            return isSuccessfulResponse;
+        }
+
+        public bool GetSpaceCutout(double ra, double dec, double plateScale)
+        {
+            return FetchSDSSCutout(ra, dec, plateScale);
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -88,8 +88,9 @@ namespace GalaxyZooTouchTable.Services
             return response;
         }
 
-        public async Task<BitmapImage> GetSpaceCutout(double ra, double dec, double plateScale, SpaceNavigation currentLocation)
+        public async Task<BitmapImage> GetSpaceCutout(double ra, double dec)
         {
+            double plateScale = 1.75;
             BitmapImage image = null;
             //if (SDSSIsResponding)
             //{

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/CutoutService.cs
@@ -92,26 +92,18 @@ namespace GalaxyZooTouchTable.Services
         {
             double plateScale = 1.75;
             BitmapImage image = null;
-            //if (SDSSIsResponding)
-            //{
-            //    using (WebResponse response = await FetchSDSSCutout(location.Center.RightAscension, location.Center.Declination, plateScale))
-            //        if (response != null)
-            //        {
-            //            string url = response.ResponseUri.ToString();
-            //            image = BitmapFromUrl(url);
-            //        }
-            //}
-            if (DECALSIsResponding && image == null)
+            if (DECALSIsResponding)
             {
                 using (WebResponse response = await FetchDECALSCutout(location.Center.RightAscension, location.Center.Declination, plateScale))
                     if (response != null)
-                    {
-                        //string url = response.ResponseUri.ToString();
-                        //image = BitmapFromUrl(url);
                         image = await StitchImagesTogether(location, plateScale);
-                    }
             }
-            //return CreateImage(successfulResponse);
+            if (SDSSIsResponding && image == null)
+            {
+                using (WebResponse response = await FetchSDSSCutout(location.Center.RightAscension, location.Center.Declination, plateScale))
+                    if (response != null)
+                        image = BitmapFromUrl(response.ResponseUri.ToString());
+            }
             return image;
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
@@ -1,7 +1,9 @@
-﻿namespace GalaxyZooTouchTable.Services
+﻿using System.Threading.Tasks;
+
+namespace GalaxyZooTouchTable.Services
 {
     public interface ICutoutService
     {
-        bool GetSpaceCutout(double ra, double dec, double plateScale);
+        Task<string> GetSpaceCutout(double ra, double dec, double plateScale);
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace GalaxyZooTouchTable.Services
-{
-    public interface ICutoutService
-    {
-        Task<string> GetSpaceCutout(double ra, double dec, double plateScale);
-    }
-}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
@@ -1,11 +1,11 @@
-﻿using GalaxyZooTouchTable.Models;
+﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.Models;
 using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
 
 namespace GalaxyZooTouchTable.Services
 {
     public interface ICutoutService
     {
-        Task<BitmapImage> GetSpaceCutout(SpaceNavigation location);
+        Task<SpaceCutout> GetSpaceCutout(SpaceNavigation location);
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
@@ -1,0 +1,11 @@
+﻿using GalaxyZooTouchTable.Models;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace GalaxyZooTouchTable.Services
+{
+    public interface ICutoutService
+    {
+        Task<BitmapImage> GetSpaceCutout(SpaceNavigation location);
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ICutoutService.cs
@@ -1,0 +1,7 @@
+﻿namespace GalaxyZooTouchTable.Services
+{
+    public interface ICutoutService
+    {
+        bool GetSpaceCutout(double ra, double dec, double plateScale);
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -30,6 +30,13 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _showError, value);
         }
 
+        private bool _canMoveMap = false;
+        public bool CanMoveMap
+        {
+            get => _canMoveMap;
+            set => SetProperty(ref _canMoveMap, value);
+        }
+
         private string _errorMessage;
         public string ErrorMessage
         {
@@ -111,17 +118,16 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void LoadCommands()
         {
-            MoveViewNorth = new CustomCommand(OnMoveViewNorth);
-            MoveViewEast = new CustomCommand(OnMoveViewEast);
-            MoveViewSouth = new CustomCommand(OnMoveViewSouth);
-            MoveViewWest = new CustomCommand(OnMoveViewWest);
+            MoveViewNorth = new CustomCommand(OnMoveViewNorth, OnCanMoveMap);
+            MoveViewEast = new CustomCommand(OnMoveViewEast, OnCanMoveMap);
+            MoveViewSouth = new CustomCommand(OnMoveViewSouth, OnCanMoveMap);
+            MoveViewWest = new CustomCommand(OnMoveViewWest, OnCanMoveMap);
             HideError = new CustomCommand(OnHideError);
         }
 
-        private void OnHideError(object obj)
-        {
-            ShowError = false;
-        }
+        private bool OnCanMoveMap(object obj) { return CanMoveMap; }
+
+        private void OnHideError(object obj) { ShowError = false; }
 
         private void OnShowError(string message)
         {
@@ -172,6 +178,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async void SetPeripheralItems()
         {
+            CanMoveMap = false;
             SpaceNavigation northern = new SpaceNavigation(CurrentLocation.NextNorthernPoint());
             SpaceNavigation southern = new SpaceNavigation(CurrentLocation.NextSouthernPoint());
             SpaceNavigation eastern = new SpaceNavigation(CurrentLocation.NextEasternPoint());
@@ -181,6 +188,7 @@ namespace GalaxyZooTouchTable.ViewModels
             PeripheralItems.Southern = await GetPeripheralItem(southern);
             PeripheralItems.Eastern = await GetPeripheralItem(eastern);
             PeripheralItems.Western = await GetPeripheralItem(western);
+            CanMoveMap = true;
         }
 
         private async Task<PeripheralItem> GetPeripheralItem(SpaceNavigation location)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -68,13 +68,6 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private bool _isDECALS = false;
-        public bool IsDECALS
-        {
-            get => _isDECALS;
-            set => SetProperty(ref _isDECALS, value);
-        }
-
         public PeripheralItems PeripheralItems { get; set; } = new PeripheralItems();
 
         public SpaceViewModel(ILocalDBService localDBService, ICutoutService cutoutService)
@@ -184,9 +177,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async void SetSpaceCutout()
         {
-            SpaceCutout cutout = await _cutoutService.GetSpaceCutout(CurrentLocation);
-            IsDECALS = cutout.IsDECALS;
-            SpaceCutoutUrl = cutout;
+            SpaceCutoutUrl = await _cutoutService.GetSpaceCutout(CurrentLocation);
         }
 
         private async void SetPeripheralItems()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -167,7 +167,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async void SetSpaceCutout()
         {
-            SpaceCutoutUrl = await CutoutService.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination);
+            SpaceCutoutUrl = await CutoutService.GetSpaceCutout(CurrentLocation);
         }
 
         private async void SetPeripheralItems()
@@ -193,7 +193,7 @@ namespace GalaxyZooTouchTable.ViewModels
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextAscendingDec(location.MaxDec));
                 periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
             }
-            periphery.Cutout = await CutoutService.GetSpaceCutout(periphery.Location.Center.RightAscension, periphery.Location.Center.Declination);
+            periphery.Cutout = await CutoutService.GetSpaceCutout(periphery.Location);
             return periphery;
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -4,7 +4,6 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Windows.Input;
 
 namespace GalaxyZooTouchTable.ViewModels
@@ -16,6 +15,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private double DecRange { get; set; }
         public SpaceNavigation CurrentLocation { get; set; }
         public event Action<CardinalDirectionEnum> AnimateMovement = delegate { };
+        CutoutService CutoutService = new CutoutService();
 
         public ICommand MoveViewNorth { get; private set; }
         public ICommand MoveViewEast { get; set; }
@@ -43,8 +43,7 @@ namespace GalaxyZooTouchTable.ViewModels
             get => _currentGalaxies;
             set 
             {
-                if (value.Count > 0)
-                    SpaceCutoutUrl = UpdateSpaceCutout();
+                UpdateSpaceCutout();
                 SetProperty(ref _currentGalaxies, value);
             }
         }
@@ -184,14 +183,10 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry(entry: "Move_Map", context: "North");
         }
 
-        private string UpdateSpaceCutout()
+        private async void UpdateSpaceCutout()
         {
             double WidenedPlateScale = 1.75;
-
-            CutoutService service = new CutoutService();
-            service.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination, WidenedPlateScale);
-
-            return $"http://legacysurvey.org/viewer-dev/jpeg-cutout/?ra={CurrentLocation.Center.RightAscension}&dec={CurrentLocation.Center.Declination}&pixscale=1.75&layer=decals-dr7&size=432";
+            SpaceCutoutUrl = await CutoutService.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination, WidenedPlateScale);
         }
 
         private List<TableSubject> FindGalaxiesAtNewBounds(CardinalDirectionEnum direction = CardinalDirectionEnum.None)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -4,6 +4,7 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Windows.Input;
 
 namespace GalaxyZooTouchTable.ViewModels
@@ -186,7 +187,11 @@ namespace GalaxyZooTouchTable.ViewModels
         private string UpdateSpaceCutout()
         {
             double WidenedPlateScale = 1.75;
-            return $"http://skyserver.sdss.org/dr14/SkyServerWS/ImgCutout/getjpeg?ra={CurrentLocation.Center.RightAscension}&dec={CurrentLocation.Center.Declination}&width=1248&height=432&scale={WidenedPlateScale}";
+
+            CutoutService service = new CutoutService();
+            service.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination, WidenedPlateScale);
+
+            return $"http://legacysurvey.org/viewer-dev/jpeg-cutout/?ra={CurrentLocation.Center.RightAscension}&dec={CurrentLocation.Center.Declination}&pixscale=1.75&layer=decals-dr7&size=432";
         }
 
         private List<TableSubject> FindGalaxiesAtNewBounds(CardinalDirectionEnum direction = CardinalDirectionEnum.None)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -5,14 +5,13 @@ using GalaxyZooTouchTable.Utility;
 using System;
 using System.Collections.Generic;
 using System.Windows.Input;
+using System.Windows.Media.Imaging;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
     public class SpaceViewModel : ViewModelBase
     {
         private ILocalDBService _localDBService;
-        private double RaRange { get; set; }
-        private double DecRange { get; set; }
         public SpaceNavigation CurrentLocation { get; set; }
         public event Action<CardinalDirectionEnum> AnimateMovement = delegate { };
         CutoutService CutoutService = new CutoutService();
@@ -48,15 +47,15 @@ namespace GalaxyZooTouchTable.ViewModels
             }
         }
 
-        private string _previousSpaceCutoutUrl;
-        public string PreviousSpaceCutoutUrl
+        private BitmapImage _previousSpaceCutoutUrl;
+        public BitmapImage PreviousSpaceCutoutUrl
         {
             get => _previousSpaceCutoutUrl;
             set => SetProperty(ref _previousSpaceCutoutUrl, value);
         }
 
-        private string _spaceCutoutUrl;
-        public string SpaceCutoutUrl
+        private BitmapImage _spaceCutoutUrl;
+        public BitmapImage SpaceCutoutUrl
         {
             get => _spaceCutoutUrl;
             set
@@ -186,7 +185,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private async void UpdateSpaceCutout()
         {
             double WidenedPlateScale = 1.75;
-            SpaceCutoutUrl = await CutoutService.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination, WidenedPlateScale);
+            SpaceCutoutUrl = await CutoutService.GetSpaceCutout(CurrentLocation.Center.RightAscension, CurrentLocation.Center.Declination, WidenedPlateScale, CurrentLocation);
         }
 
         private List<TableSubject> FindGalaxiesAtNewBounds(CardinalDirectionEnum direction = CardinalDirectionEnum.None)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Windows.Media.Imaging;
 
 namespace GalaxyZooTouchTable.ViewModels
 {
@@ -51,15 +50,15 @@ namespace GalaxyZooTouchTable.ViewModels
             set => SetProperty(ref _currentGalaxies, value);
         }
 
-        private BitmapImage _previousSpaceCutoutUrl;
-        public BitmapImage PreviousSpaceCutoutUrl
+        private SpaceCutout _previousSpaceCutoutUrl;
+        public SpaceCutout PreviousSpaceCutoutUrl
         {
             get => _previousSpaceCutoutUrl;
             set => SetProperty(ref _previousSpaceCutoutUrl, value);
         }
 
-        private BitmapImage _spaceCutoutUrl;
-        public BitmapImage SpaceCutoutUrl
+        private SpaceCutout _spaceCutoutUrl;
+        public SpaceCutout SpaceCutoutUrl
         {
             get => _spaceCutoutUrl;
             set
@@ -67,6 +66,13 @@ namespace GalaxyZooTouchTable.ViewModels
                 PreviousSpaceCutoutUrl = _spaceCutoutUrl;
                 SetProperty(ref _spaceCutoutUrl, value);
             }
+        }
+
+        private bool _isDECALS = false;
+        public bool IsDECALS
+        {
+            get => _isDECALS;
+            set => SetProperty(ref _isDECALS, value);
         }
 
         public PeripheralItems PeripheralItems { get; set; } = new PeripheralItems();
@@ -178,7 +184,9 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async void SetSpaceCutout()
         {
-            SpaceCutoutUrl = await _cutoutService.GetSpaceCutout(CurrentLocation);
+            SpaceCutout cutout = await _cutoutService.GetSpaceCutout(CurrentLocation);
+            IsDECALS = cutout.IsDECALS;
+            SpaceCutoutUrl = cutout;
         }
 
         private async void SetPeripheralItems()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ViewModelLocator.cs
@@ -16,6 +16,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public ViewModelLocator()
         {
             container.RegisterType<ILocalDBService, LocalDBService>();
+            container.RegisterType<ICutoutService, CutoutService>();
             container.RegisterType<IGraphQLService, GraphQLService>();
             _spaceViewModel = container.Resolve<SpaceViewModel>();
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -67,8 +67,8 @@
                                         StrokeDashCap="Round"
                                         StrokeThickness="5"    
                                         Stroke="{Binding UserColor}"
-                                        RadiusX="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=CornerRadius.TopRight}"
-                                        RadiusY="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=CornerRadius.BottomLeft}"
+                                        RadiusX="100"
+                                        RadiusY="100"
                                         Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=ActualWidth}"
                                         Height="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=ActualHeight}"/>
                                 </VisualBrush.Visual>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -69,8 +69,8 @@
                                         Stroke="{Binding UserColor}"
                                         RadiusX="100"
                                         RadiusY="100"
-                                        Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=ActualWidth}"
-                                        Height="{Binding RelativeSource={RelativeSource AncestorType={x:Type Border}}, Path=ActualHeight}"/>
+                                        Width="100"
+                                        Height="100"/>
                                 </VisualBrush.Visual>
                             </VisualBrush>
                         </Border.BorderBrush>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -6,6 +6,7 @@
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
              xmlns:views="clr-namespace:GalaxyZooTouchTable.Views"
+             xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF"
              mc:Ignorable="d" 
              Height="432"
              Width="1248"
@@ -26,7 +27,6 @@
             <Setter Property="FontFamily" Value="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
             <Setter Property="FontSize" Value="10"/>
             <Setter Property="FontWeight" Value="Bold"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="Text" Value="Move map"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
@@ -36,6 +36,24 @@
             <Style.Triggers>
                 <DataTrigger Binding="{Binding Path=ShowError}" Value="False">
                     <Setter Property="Visibility" Value="Collapsed"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="DownArrow" TargetType="{x:Type fa:ImageAwesome}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding CanMoveMap}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="LoadingSpinner" TargetType="{x:Type fa:ImageAwesome}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding CanMoveMap}" Value="False">
+                    <Setter Property="Visibility" Value="Visible"/>
                 </DataTrigger>
             </Style.Triggers>
         </Style>
@@ -74,43 +92,55 @@
 
             <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Top">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TempDisableBorder ObservedElement="{Binding CurrentGalaxies}"/>
                     <Behaviors:TapBehavior Command="{Binding MoveViewNorth}"/>
                 </i:Interaction.Behaviors>
                 <Border.LayoutTransform>
                     <RotateTransform Angle="180"/>
                 </Border.LayoutTransform>
-                <TextBlock Style="{StaticResource MoveMapText}"/>
+                <StackPanel Orientation="Horizontal" Margin="10,0">
+                    <TextBlock Style="{StaticResource MoveMapText}"/>
+                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                </StackPanel>
             </Border>
 
             <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Top">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TempDisableBorder ObservedElement="{Binding CurrentGalaxies}"/>
                     <Behaviors:TapBehavior Command="{Binding MoveViewEast}"/>
                 </i:Interaction.Behaviors>
                 <Border.LayoutTransform>
                     <RotateTransform Angle="-90"/>
                 </Border.LayoutTransform>
-                <TextBlock Style="{StaticResource MoveMapText}"/>
+                <StackPanel Orientation="Horizontal" Margin="10,0">
+                    <TextBlock Style="{StaticResource MoveMapText}"/>
+                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                </StackPanel>
             </Border>
 
             <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Bottom">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TempDisableBorder ObservedElement="{Binding CurrentGalaxies}"/>
                     <Behaviors:TapBehavior Command="{Binding MoveViewWest}"/>
                 </i:Interaction.Behaviors>
                 <Border.LayoutTransform>
                     <RotateTransform Angle="90"/>
                 </Border.LayoutTransform>
-                <TextBlock Style="{StaticResource MoveMapText}"/>
+                <StackPanel Orientation="Horizontal" Margin="10,0">
+                    <TextBlock Style="{StaticResource MoveMapText}"/>
+                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                </StackPanel>
             </Border>
 
             <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Bottom">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TempDisableBorder ObservedElement="{Binding CurrentGalaxies}"/>
                     <Behaviors:TapBehavior Command="{Binding MoveViewSouth}"/>
                 </i:Interaction.Behaviors>
-                <TextBlock Style="{StaticResource MoveMapText}"/>
+                <StackPanel Orientation="Horizontal" Margin="10,0">
+                    <TextBlock Style="{StaticResource MoveMapText}"/>
+                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                </StackPanel>
             </Border>
             <StackPanel Style="{StaticResource ErrorPanel}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Orientation="Horizontal">
                 <TextBlock Text="{Binding ErrorMessage}" Foreground="Red"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -65,10 +65,18 @@
         </Border.Effect>
         <Grid ClipToBounds="True">
             <Border x:Name="CurrentCutout" RenderTransformOrigin="0.5,0.5" Width="1248" Height="432">
-                <Image x:Name="CurrentCutoutImage" RenderTransformOrigin="0.5,0.5" Source="{Binding SpaceCutoutUrl}"/>
+                <Grid x:Name="CurrentCutoutImage" RenderTransformOrigin="0.5,0.5">
+                    <Image Source="{Binding SpaceCutoutUrl.ImageOne}"/>
+                    <Image Source="{Binding SpaceCutoutUrl.ImageTwo}" HorizontalAlignment="Left"/>
+                    <Image Source="{Binding SpaceCutoutUrl.ImageThree}" HorizontalAlignment="Right"/>
+                </Grid>
             </Border>
             <Border x:Name="PreviousCutout" RenderTransformOrigin="0.5,0.5" Width="1248" Height="432">
-                <Image x:Name="PreviousCutoutImage" RenderTransformOrigin="0.5,0.5" Source="{Binding PreviousSpaceCutoutUrl}"/>
+                <Grid x:Name="PreviousCutoutImage" RenderTransformOrigin="0.5,0.5">
+                    <Image Source="{Binding PreviousSpaceCutoutUrl.ImageOne}"/>
+                    <Image Source="{Binding PreviousSpaceCutoutUrl.ImageTwo}" HorizontalAlignment="Left"/>
+                    <Image Source="{Binding PreviousSpaceCutoutUrl.ImageThree}" HorizontalAlignment="Right"/>
+                </Grid>
             </Border>
 
             <ItemsControl x:Name="VisibleGalaxies" ItemsSource="{Binding CurrentGalaxies}">


### PR DESCRIPTION
Describe your changes.
With the changes here, we now rely on two cutout services (DECALS & Sloan) in the instance one of those services goes down. If both are down, or we lose internet connection, the background space image will be blank.

A few things of note:
- When a cutout service isn't responding, we take a ten minute break from trying to fetch images there.
- Unfortunately DECALS only returns squared images, so I have to stitch together three images for the background.
- DECALS takes about 10-15 seconds to load while navigating while Sloan takes around one second. Unfortunately, our subjects come from the DECALS survey.

Closes #54 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
