### PR TITLE
Close Log with Application Exit

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
@@ -3,9 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GalaxyZooTouchTable"
              xmlns:ViewModels="clr-namespace:GalaxyZooTouchTable.ViewModels"
-             xmlns:Models="clr-namespace:GalaxyZooTouchTable.Models"
              xmlns:Converters="clr-namespace:GalaxyZooTouchTable.Converters"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib">
+             Startup="Application_Startup"
+             Exit="Application_Exit">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GalaxyZooTouchTable.ViewModels;
+﻿using GalaxyZooTouchTable.Lib;
+using GalaxyZooTouchTable.ViewModels;
 using System;
 using System.Windows;
 
@@ -18,6 +19,16 @@ namespace GalaxyZooTouchTable
 
             var mainWindow = new MainWindow(new MainWindowViewModel());
             mainWindow.Show();
+        }
+
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            GlobalData.GetInstance().EstablishLog();
+        }
+
+        private void Application_Exit(object sender, ExitEventArgs e)
+        {
+            GlobalData.GetInstance().Logger?.FinalizeLog();
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
@@ -1,6 +1,4 @@
-using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.ViewModels;
-using System;
 using System.Windows;
 using System.Windows.Input;
 
@@ -17,7 +15,6 @@ namespace GalaxyZooTouchTable
         {
             InitializeComponent();
             Loaded += MainWindow_Loaded;
-            Closed += MainWindow_Closed;
 
             _viewModel = viewModel;
             DataContext = viewModel;
@@ -27,13 +24,7 @@ namespace GalaxyZooTouchTable
 
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            GlobalData.GetInstance().EstablishLog();
             _viewModel.Load();
-        }
-
-        private void MainWindow_Closed(object sender, EventArgs e)
-        {
-            GlobalData.GetInstance().Logger?.FinalizeLog();
         }
     }
 }


### PR DESCRIPTION
Describe your changes.
The app doesn't close log files correctly with the current setup. Instead, logs should be closed on the application exit.

Fixes # .

# Review Checklist

- [ ] Are tests passing?
- [ ] Is the build free of output errors?
