### PR TITLE
Account for Retired Galaxies

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/GalaxyZooTouchTable.Tests.csproj
@@ -93,6 +93,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\NotifyPropertyChangedExtensions.cs" />
+    <Compile Include="Mock\CutoutServiceMockData.cs" />
     <Compile Include="Mock\GraphQLServiceMockData.cs" />
     <Compile Include="Mock\PanoptesServiceMockData.cs" />
     <Compile Include="Mock\SpaceNavigationMockData.cs" />

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/CutoutServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/CutoutServiceMockData.cs
@@ -1,0 +1,14 @@
+﻿using GalaxyZooTouchTable.Lib;
+
+namespace GalaxyZooTouchTable.Tests.Mock
+{
+    public static class CutoutServiceMockData
+    {
+        public static SpaceCutout SpaceCutout()
+        {
+            SpaceCutout cutout = new SpaceCutout();
+            cutout.ImageOne = new System.Windows.Media.Imaging.BitmapImage();
+            return cutout;
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/Mock/PanoptesServiceMockData.cs
@@ -19,7 +19,7 @@ namespace GalaxyZooTouchTable.Tests.Mock
 
         public static TableSubject TableSubject()
         {
-            return new TableSubject("1", "www.fakewebsite.com", 22.22, 33.33);
+            return new TableSubject("1", "www.fakewebsite.com", 22.22, 33.33, 5);
         }
 
         public static Workflow Workflow(string id = null)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -23,6 +23,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _panoptesServiceMock.Setup(dp => dp.CreateClassificationAsync(It.IsAny<Classification>()))
                 .ReturnsAsync(new ClassificationCounts(1,0,0,1));
 
+            _localDBServiceMock.Setup(dp => dp.CheckIfSubjectRetired(It.IsAny<string>())).Returns(false);
             _localDBServiceMock.Setup(dp => dp.GetLocalSubject(It.IsAny<string>())).Returns(PanoptesServiceMockData.TableSubject());
             _localDBServiceMock.Setup(dp => dp.GetQueuedSubjects()).Returns(PanoptesServiceMockData.TableSubjects());
 
@@ -160,6 +161,34 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         {
             _viewModel.ShowCloseConfirmation.Execute(null);
             Assert.True(_viewModel.ShowOverlay);
+        }
+
+        [Fact]
+        private void ShouldNotShowSubjectRetired()
+        {
+            _viewModel.Load();
+            _viewModel.DropSubject(PanoptesServiceMockData.TableSubject());
+            Assert.False(_viewModel.ShowRetirementModal);
+        }
+    }
+
+    public class ClassificationPanelRetiredSubjectTests
+    {
+        private ClassificationPanelViewModel _viewModel { get; set; }
+        private Mock<IPanoptesService> _panoptesServiceMock = new Mock<IPanoptesService>();
+        private Mock<ILocalDBService> _localDBServiceMock = new Mock<ILocalDBService>();
+
+        public ClassificationPanelRetiredSubjectTests()
+        {
+            _localDBServiceMock.Setup(dp => dp.CheckIfSubjectRetired(It.IsAny<string>())).Returns(true);
+            _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _localDBServiceMock.Object, new BlueUser());
+        }
+
+        [Fact]
+        private void ShouldShowRetirementModal()
+        {
+            _viewModel.DropSubject(PanoptesServiceMockData.TableSubject());
+            Assert.True(_viewModel.ShowRetirementModal);
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -23,7 +23,6 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             _panoptesServiceMock.Setup(dp => dp.CreateClassificationAsync(It.IsAny<Classification>()))
                 .ReturnsAsync(new ClassificationCounts(1,0,0,1));
 
-            _localDBServiceMock.Setup(dp => dp.CheckIfSubjectRetired(It.IsAny<string>())).Returns(false);
             _localDBServiceMock.Setup(dp => dp.GetLocalSubject(It.IsAny<string>())).Returns(PanoptesServiceMockData.TableSubject());
             _localDBServiceMock.Setup(dp => dp.GetQueuedSubjects()).Returns(PanoptesServiceMockData.TableSubjects());
 
@@ -180,7 +179,6 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
 
         public ClassificationPanelRetiredSubjectTests()
         {
-            _localDBServiceMock.Setup(dp => dp.CheckIfSubjectRetired(It.IsAny<string>())).Returns(true);
             _viewModel = new ClassificationPanelViewModel(_panoptesServiceMock.Object, _localDBServiceMock.Object, new BlueUser());
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/ClassificationPanelViewModelTests.cs
@@ -185,7 +185,9 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         [Fact]
         private void ShouldShowRetirementModal()
         {
-            _viewModel.DropSubject(PanoptesServiceMockData.TableSubject());
+            TableSubject subject = PanoptesServiceMockData.TableSubject();
+            subject.IsRetired = true;
+            _viewModel.DropSubject(subject);
             Assert.True(_viewModel.ShowRetirementModal);
         }
     }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/SpaceViewModelTests.cs
@@ -17,9 +17,11 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         public SpaceViewModelTests()
         {
             _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(SpaceNavigationMockData.Center());
-            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>()))
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>(), true))
                 .Returns(PanoptesServiceMockData.TableSubjects());
-
+            _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>(), false))
+                .Returns(PanoptesServiceMockData.TableSubjects());
+            _cutoutServiceMock.Setup(dp => dp.GetSpaceCutout(It.IsAny<SpaceNavigation>())).ReturnsAsync(CutoutServiceMockData.SpaceCutout());
             _viewModel = new SpaceViewModel(_localDBServiceMock.Object, _cutoutServiceMock.Object);
         }
 
@@ -30,7 +32,8 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             Assert.NotNull(_viewModel.CurrentGalaxies);
             Assert.False(_viewModel.ShowError);
             _localDBServiceMock.Verify(vm => vm.GetRandomPoint(), Times.Once);
-            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(It.IsAny<SpaceNavigation>()), Times.Exactly(5));
+            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(It.IsAny<SpaceNavigation>(), true), Times.Once);
+            _localDBServiceMock.Verify(vm => vm.GetLocalSubjects(It.IsAny<SpaceNavigation>(), false), Times.Exactly(4));
         }
 
         public class EmptyResultsAtNextTile
@@ -47,7 +50,9 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
                 _localDBServiceMock.Setup(dp => dp.FindNextAscendingRa(It.IsAny<double>())).Returns(new SpacePoint(20,0));
                 _localDBServiceMock.Setup(dp => dp.FindNextDescendingRa(It.IsAny<double>())).Returns(new SpacePoint(-20,0));
                 _localDBServiceMock.Setup(dp => dp.GetRandomPoint()).Returns(SpaceNavigationMockData.Center());
-                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>()))
+                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>(), true))
+                    .Returns(new List<TableSubject>());
+                _localDBServiceMock.Setup(dp => dp.GetLocalSubjects(It.IsAny<SpaceNavigation>(), false))
                     .Returns(new List<TableSubject>());
                 _cutoutServiceMock.Setup(dp => dp.GetSpaceCutout(It.IsAny<SpaceNavigation>())).ReturnsAsync(new Lib.SpaceCutout());
 
@@ -79,7 +84,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             {
                 double OldDec = _viewModel.CurrentLocation.Center.Declination;
                 _viewModel.MoveViewSouth.Execute(null);
-                Assert.True(OldDec < _viewModel.CurrentLocation.Center.Declination);
+                Assert.True(OldDec > _viewModel.CurrentLocation.Center.Declination);
                 _localDBServiceMock.Verify(vm => vm.FindNextAscendingDec(It.IsAny<double>()), Times.AtLeastOnce);
                 _cutoutServiceMock.Verify(vm => vm.GetSpaceCutout(It.IsAny<SpaceNavigation>()), Times.AtLeastOnce);
             }
@@ -89,7 +94,7 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             {
                 double OldRa = _viewModel.CurrentLocation.Center.RightAscension;
                 _viewModel.MoveViewWest.Execute(null);
-                Assert.True(OldRa > _viewModel.CurrentLocation.Center.RightAscension);
+                Assert.True(OldRa < _viewModel.CurrentLocation.Center.RightAscension);
                 _localDBServiceMock.Verify(vm => vm.FindNextAscendingDec(It.IsAny<double>()), Times.AtLeastOnce);
                 _cutoutServiceMock.Verify(vm => vm.GetSpaceCutout(It.IsAny<SpaceNavigation>()), Times.AtLeastOnce);
             }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -287,6 +287,9 @@
     <Compile Include="Views\MultiTouchButton.xaml.cs">
       <DependentUpon>MultiTouchButton.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\RetiredSubjectModal.xaml.cs">
+      <DependentUpon>RetiredSubjectModal.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SpaceView.xaml.cs">
       <DependentUpon>SpaceView.xaml</DependentUpon>
     </Compile>
@@ -448,6 +451,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\MultiTouchButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\RetiredSubjectModal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Win32.SafeHandles;
+﻿using GalaxyZooTouchTable.ViewModels;
+using Microsoft.Win32.SafeHandles;
 using PanoptesNetClient.Models;
 using System;
 using System.Collections.ObjectModel;
@@ -7,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace GalaxyZooTouchTable.Models
 {
-    public class TableSubject : IDisposable
+    public class TableSubject : ViewModelBase,  IDisposable
     {
         SpaceNavigation CurrentLocation { get; set; }
         public int X { get; set; }
@@ -20,6 +21,14 @@ namespace GalaxyZooTouchTable.Models
         public ObservableCollection<GalaxyRing> GalaxyRings { get; set; } = new ObservableCollection<GalaxyRing>();
         public string Id { get; set; }
         bool disposed = false;
+
+        private bool _isRetired = false;
+        public bool IsRetired
+        {
+            get => _isRetired;
+            set => SetProperty(ref _isRetired, value);
+        }
+
         SafeHandle handle = new SafeFileHandle(IntPtr.Zero, true);
 
         public TableSubject(string id, string location, double ra, double dec, SpaceNavigation currentLocation = null)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -10,6 +10,7 @@ namespace GalaxyZooTouchTable.Models
 {
     public class TableSubject : ViewModelBase,  IDisposable
     {
+        readonly int RETIRED_LIMIT = 25;
         SpaceNavigation CurrentLocation { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
@@ -31,7 +32,7 @@ namespace GalaxyZooTouchTable.Models
 
         SafeHandle handle = new SafeFileHandle(IntPtr.Zero, true);
 
-        public TableSubject(string id, string location, double ra, double dec, SpaceNavigation currentLocation = null)
+        public TableSubject(string id, string location, double ra, double dec, int classificationCount, SpaceNavigation currentLocation = null)
         {
             CurrentLocation = currentLocation;
             GalaxyRings.Add(new GalaxyRing());
@@ -41,6 +42,7 @@ namespace GalaxyZooTouchTable.Models
             Declination = dec;
             SubjectLocation = location;
             if (currentLocation != null) XYConvert();
+            IsRetired = classificationCount >= RETIRED_LIMIT;
         }
 
         private void XYConvert()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -9,7 +9,7 @@ namespace GalaxyZooTouchTable.Services
     {
         TableSubject GetLocalSubject(string id);
 
-        List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation);
+        List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation, bool returnIfRetired = false);
         List<TableSubject> GetQueuedSubjects();
         List<TableSubject> GetSubjects(string query, SpaceNavigation currentLocation = null);
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -27,5 +27,6 @@ namespace GalaxyZooTouchTable.Services
         Task UpdateDBFromGraphQL(string id);
 
         void UpdateSubject(string id, ClassificationCounts counts);
+        bool CheckIfSubjectRetired(string id);
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -11,7 +11,7 @@ namespace GalaxyZooTouchTable.Services
 
         List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation, bool returnIfRetired = false);
         List<TableSubject> GetQueuedSubjects();
-        List<TableSubject> GetSubjects(string query, SpaceNavigation currentLocation = null);
+        List<TableSubject> GetSubjects(string query, bool returnIfRetired, SpaceNavigation currentLocation = null);
 
         SpacePoint FindNextAscendingRa(double raLowerBounds);
         SpacePoint FindNextDescendingRa(double raUpperBounds);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/ILocalDBService.cs
@@ -27,6 +27,5 @@ namespace GalaxyZooTouchTable.Services
         Task UpdateDBFromGraphQL(string id);
 
         void UpdateSubject(string id, ClassificationCounts counts);
-        bool CheckIfSubjectRetired(string id);
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -14,6 +14,7 @@ namespace GalaxyZooTouchTable.Services
     {
         readonly int RETIREMENT_LIMIT = 25;
         readonly string QueuedSubjectsQuery = "select * from Subjects order by classifications_count asc, random() limit 10";
+        readonly string QueuedSubjectQuery = "select * from Subjects order by classifications_count asc, random() limit 1";
         string HighestRaQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by ra desc limit 1"; }
         string HighestDecQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by dec desc limit 1"; }
         string LowestRaQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by ra asc limit 1"; }
@@ -156,22 +157,22 @@ namespace GalaxyZooTouchTable.Services
 
         public SpacePoint FindNextAscendingRa(double bounds)
         {
-            return GetPoint(NextAscendingRaQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(LowestRaQuery(RETIREMENT_LIMIT));
+            return GetPoint(NextAscendingRaQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(LowestRaQuery(RETIREMENT_LIMIT)) ?? GetPoint(QueuedSubjectQuery);
         }
 
         public SpacePoint FindNextDescendingRa(double bounds)
         {
-            return GetPoint(NextDescendingRaQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(HighestRaQuery(RETIREMENT_LIMIT));
+            return GetPoint(NextDescendingRaQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(HighestRaQuery(RETIREMENT_LIMIT)) ?? GetPoint(QueuedSubjectQuery);
         }
 
         public SpacePoint FindNextAscendingDec(double bounds)
         {
-            return GetPoint(NextAscendingDecQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(LowestDecQuery(RETIREMENT_LIMIT));
+            return GetPoint(NextAscendingDecQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(LowestDecQuery(RETIREMENT_LIMIT)) ?? GetPoint(QueuedSubjectQuery);
         }
 
         public SpacePoint FindNextDescendingDec(double bounds)
         {
-            return GetPoint(NextDescendingDecQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(HighestDecQuery(RETIREMENT_LIMIT));
+            return GetPoint(NextDescendingDecQuery(bounds, RETIREMENT_LIMIT)) ?? GetPoint(HighestDecQuery(RETIREMENT_LIMIT)) ?? GetPoint(QueuedSubjectQuery);
         }
 
         public ClassificationCounts IncrementClassificationCount(Classification classification)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -18,7 +18,7 @@ namespace GalaxyZooTouchTable.Services
         string HighestRaQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by ra desc limit 1"; }
         string HighestDecQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by dec desc limit 1"; }
         string LowestRaQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by ra asc limit 1"; }
-        string LowestDecQuery(int limit) { return $"select * from Subjects order by dec asc limit 1"; }
+        string LowestDecQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by dec asc limit 1"; }
         string RandomSubjectQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by random() limit 1"; }
         string SubjectByIdQuery(string id) { return $"select * from Subjects where subject_id = {id}"; }
         string NextAscendingRaQuery(double bounds, int limit) { return $"select * from Subjects where ra > {bounds} and classifications_count < {limit} order by ra asc limit 1"; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -23,7 +23,7 @@ namespace GalaxyZooTouchTable.Services
         string NextAscendingRaQuery(double bounds, int limit) { return $"select * from Subjects where ra > {bounds} and classifications_count < {limit} order by ra asc limit 1"; }
         string NextDescendingRaQuery(double bounds, int limit) { return $"select * from Subjects where ra < {bounds} and classifications_count < {limit} order by ra desc limit 1"; }
         string NextAscendingDecQuery(double bounds, int limit) { return $"select * from Subjects where dec > {bounds} and classifications_count < {limit} order by dec asc limit 1"; }
-        string NextDescendingDecQuery(double bounds, int limit) { return $"select * from Subjects where dec < {bounds} classifications_count < {limit} order by dec desc limit 1"; }
+        string NextDescendingDecQuery(double bounds, int limit) { return $"select * from Subjects where dec < {bounds} and classifications_count < {limit} order by dec desc limit 1"; }
         string GetCurrentClassificationCount(string id) { return $"select * from Subjects where subject_id = {id}"; }
         string UpdateSubjectCounts(string id, ClassificationCounts counts) { return $"update Subjects set classifications_count = {counts.Total}, smooth = {counts.Smooth}, features = {counts.Features}, star = {counts.Star} where subject_id = {id}"; } 
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -72,16 +72,16 @@ namespace GalaxyZooTouchTable.Services
 
         public List<TableSubject> GetQueuedSubjects()
         {
-            return GetSubjects(QueuedSubjectsQuery);
+            return GetSubjects(QueuedSubjectsQuery, true);
         }
 
-        public List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation)
+        public List<TableSubject> GetLocalSubjects(SpaceNavigation currentLocation, bool returnIfRetired = false)
         {
             string query = SubjectsWithinBoundsQuery(currentLocation);
-            return GetSubjects(query, currentLocation);
+            return GetSubjects(query, returnIfRetired, currentLocation);
         }
 
-        public List<TableSubject> GetSubjects(string query, SpaceNavigation currentLocation = null)
+        public List<TableSubject> GetSubjects(string query, bool returnIfRetired, SpaceNavigation currentLocation = null)
         {
             List<string> idsToUpdate = new List<string>();
             using (SQLiteConnection connection = new SQLiteConnection($"Data Source={App.DatabasePath}"))
@@ -113,7 +113,11 @@ namespace GalaxyZooTouchTable.Services
                     Messenger.Default.Send(ErrorMessage, "DatabaseError");
                 }
                 UpdateDBFromIds(idsToUpdate);
-                return Subjects.Any(subject => !subject.IsRetired) ? Subjects : new List<TableSubject>();
+
+                if (returnIfRetired)
+                    return Subjects;
+                else
+                    return Subjects.Any(subject => !subject.IsRetired) ? Subjects : new List<TableSubject>();
             }
         }
 
@@ -152,7 +156,7 @@ namespace GalaxyZooTouchTable.Services
 
         public SpacePoint GetRandomPoint()
         {
-            return GetPoint(RandomSubjectQuery(RETIREMENT_LIMIT)) ?? new SpacePoint(0,0);
+            return GetPoint(RandomSubjectQuery(RETIREMENT_LIMIT)) ?? GetPoint(QueuedSubjectQuery);
         }
 
         public SpacePoint FindNextAscendingRa(double bounds)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -55,7 +55,8 @@ namespace GalaxyZooTouchTable.Services
                         string image = CheckLocalPath(filename) ?? reader["image"] as string;
                         double ra = (double)reader["ra"];
                         double dec = (double)reader["dec"];
-                        RetrievedSubject = new TableSubject(id, image, ra, dec);
+                        int classificationCount = Convert.ToInt32(reader["classifications_count"]);
+                        RetrievedSubject = new TableSubject(id, image, ra, dec, classificationCount);
                     }
                     connection.Close();
                 } catch (SQLiteException exception)
@@ -98,7 +99,8 @@ namespace GalaxyZooTouchTable.Services
                         string image = CheckLocalPath(filename) ?? reader["image"] as string;
                         double ra = (double)reader["ra"];
                         double dec = (double)reader["dec"];
-                        TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec, currentLocation);
+                        int classificationCount = Convert.ToInt32(reader["classifications_count"]);
+                        TableSubject RetrievedSubject = new TableSubject(id, image, ra, dec, classificationCount, currentLocation);
                         Subjects.Add(RetrievedSubject);
                     }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -338,6 +338,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public void LoadSubject(TableSubject subject)
         {
+            bool isRetired = _localDBService.CheckIfSubjectRetired(subject.Id);
             PrepareForNewClassification();
             CurrentSubject = subject;
             StartNewClassification(subject);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -270,6 +270,7 @@ namespace GalaxyZooTouchTable.ViewModels
             ClassifierOpen = false;
             CloseConfirmationViewModel.OnToggleCloseConfirmation(false);
             User.Active = false;
+            ShowRetirementModal = false;
             NotifySpaceView(RingNotifierStatus.IsLeaving);
             CompletedClassifications.Clear();
         }
@@ -390,7 +391,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             if (_localDBService.CheckIfSubjectRetired(subject.Id))
             {
-                GlobalData.GetInstance().Logger?.AddEntry("Hide_Retirement_Modal", User.Name, subject.Id, CurrentView);
+                GlobalData.GetInstance().Logger?.AddEntry("Show_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;
             }
             else

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -338,7 +338,6 @@ namespace GalaxyZooTouchTable.ViewModels
 
         public void LoadSubject(TableSubject subject)
         {
-            bool isRetired = _localDBService.CheckIfSubjectRetired(subject.Id);
             PrepareForNewClassification();
             CurrentSubject = subject;
             StartNewClassification(subject);
@@ -361,6 +360,7 @@ namespace GalaxyZooTouchTable.ViewModels
             PrepareForNewClassification();
             if (Subjects.Count == 0)
                 Subjects = _localDBService.GetQueuedSubjects();
+            bool isRetired = _localDBService.CheckIfSubjectRetired(Subjects[0].Id);
             LoadSubject(Subjects[0]);
             Subjects.RemoveAt(0);
         }
@@ -370,6 +370,8 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry("Drop_Galaxy", User.Name, subject.Id, CurrentView);
             if (CheckAlreadyCompleted(subject)) return;
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
+            bool isRetired = _localDBService.CheckIfSubjectRetired(subject.Id);
+
             LoadSubject(subject);
             NotifySpaceView(RingNotifierStatus.IsCreating);
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -285,6 +285,8 @@ namespace GalaxyZooTouchTable.ViewModels
             ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
             ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
 
+            CurrentSubject.IsRetired = true;
+
             NotifySpaceView(RingNotifierStatus.IsSubmitting);
             LevelerViewModel.OnIncrementCount();
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -3,7 +3,6 @@ using GalaxyZooTouchTable.Models;
 using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using PanoptesNetClient.Models;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -361,6 +360,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (Subjects.Count == 0)
                 Subjects = _localDBService.GetQueuedSubjects();
             bool isRetired = _localDBService.CheckIfSubjectRetired(Subjects[0].Id);
+
             LoadSubject(Subjects[0]);
             Subjects.RemoveAt(0);
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -391,7 +391,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             if (_localDBService.CheckIfSubjectRetired(subject.Id))
             {
-                GlobalData.GetInstance().Logger?.AddEntry("Hide_Retirement_Modal", User.Name, subject.Id, CurrentView);
+                GlobalData.GetInstance().Logger?.AddEntry("Show_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;
             }
             else

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -270,7 +270,6 @@ namespace GalaxyZooTouchTable.ViewModels
             ClassifierOpen = false;
             CloseConfirmationViewModel.OnToggleCloseConfirmation(false);
             User.Active = false;
-            ShowRetirementModal = false;
             NotifySpaceView(RingNotifierStatus.IsLeaving);
             CompletedClassifications.Clear();
         }
@@ -391,7 +390,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             if (_localDBService.CheckIfSubjectRetired(subject.Id))
             {
-                GlobalData.GetInstance().Logger?.AddEntry("Show_Retirement_Modal", User.Name, subject.Id, CurrentView);
+                GlobalData.GetInstance().Logger?.AddEntry("Hide_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;
             }
             else

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -220,6 +220,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void OnHideRetirementModal(object obj)
         {
             ShowRetirementModal = false;
+            StartStillThereModalTimer();
         }
 
         private void OnShowCloseConfirmation(object obj)
@@ -269,6 +270,7 @@ namespace GalaxyZooTouchTable.ViewModels
             ClassifierOpen = false;
             CloseConfirmationViewModel.OnToggleCloseConfirmation(false);
             User.Active = false;
+            ShowRetirementModal = false;
             NotifySpaceView(RingNotifierStatus.IsLeaving);
             CompletedClassifications.Clear();
         }
@@ -387,7 +389,7 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry("Drop_Galaxy", User.Name, subject.Id, CurrentView);
             if (CheckAlreadyCompleted(subject)) return;
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
-            if (_localDBService.CheckIfSubjectRetired(subject.Id))
+            if (true)
             {
                 GlobalData.GetInstance().Logger?.AddEntry("Hide_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -389,7 +389,7 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry("Drop_Galaxy", User.Name, subject.Id, CurrentView);
             if (CheckAlreadyCompleted(subject)) return;
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
-            if (true)
+            if (_localDBService.CheckIfSubjectRetired(subject.Id))
             {
                 GlobalData.GetInstance().Logger?.AddEntry("Hide_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -15,6 +15,7 @@ namespace GalaxyZooTouchTable.ViewModels
 {
     public class ClassificationPanelViewModel : ViewModelBase
     {
+        readonly int RETIRED_LIMIT = 25;
         private IPanoptesService _panoptesService;
         private ILocalDBService _localDBService;
         private List<CompletedClassification> CompletedClassifications { get; set; } = new List<CompletedClassification>();
@@ -284,9 +285,7 @@ namespace GalaxyZooTouchTable.ViewModels
             HandleCompletedClassification();
             ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
             ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
-
-            CurrentSubject.IsRetired = true;
-
+            if (counts.Total >= RETIRED_LIMIT) CurrentSubject.IsRetired = true;
             NotifySpaceView(RingNotifierStatus.IsSubmitting);
             LevelerViewModel.OnIncrementCount();
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());
@@ -391,7 +390,7 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry("Drop_Galaxy", User.Name, subject.Id, CurrentView);
             if (CheckAlreadyCompleted(subject)) return;
             if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
-            if (_localDBService.CheckIfSubjectRetired(subject.Id))
+            if (subject.IsRetired)
             {
                 GlobalData.GetInstance().Logger?.AddEntry("Show_Retirement_Modal", User.Name, subject.Id, CurrentView);
                 ShowRetirementModal = true;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -183,14 +183,14 @@ namespace GalaxyZooTouchTable.ViewModels
         private async void SetPeripheralItems()
         {
             CanMoveMap = false;
-            PeripheralItems.Northern = await GetPeripheralItem(new SpaceNavigation(CurrentLocation.NextNorthernPoint()));
-            PeripheralItems.Southern = await GetPeripheralItem(new SpaceNavigation(CurrentLocation.NextSouthernPoint()));
-            PeripheralItems.Eastern = await GetPeripheralItem(new SpaceNavigation(CurrentLocation.NextEasternPoint()));
-            PeripheralItems.Western = await GetPeripheralItem(new SpaceNavigation(CurrentLocation.NextWesternPoint()));
+            PeripheralItems.Northern = await GetPeripheralNorth(new SpaceNavigation(CurrentLocation.NextNorthernPoint()));
+            PeripheralItems.Southern = await GetPeripheralSouth(new SpaceNavigation(CurrentLocation.NextSouthernPoint()));
+            PeripheralItems.Eastern = await GetPeripheralEast(new SpaceNavigation(CurrentLocation.NextEasternPoint()));
+            PeripheralItems.Western = await GetPeripheralWest(new SpaceNavigation(CurrentLocation.NextWesternPoint()));
             CanMoveMap = true;
         }
 
-        private async Task<PeripheralItem> GetPeripheralItem(SpaceNavigation location)
+        private async Task<PeripheralItem> GetPeripheralNorth(SpaceNavigation location)
         {
             PeripheralItem periphery = new PeripheralItem(location);
             periphery.Galaxies = _localDBService.GetLocalSubjects(location);
@@ -198,6 +198,48 @@ namespace GalaxyZooTouchTable.ViewModels
             if (periphery.Galaxies.Count == 0)
             {
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextAscendingDec(location.MaxDec));
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+            }
+            periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
+            return periphery;
+        }
+
+        private async Task<PeripheralItem> GetPeripheralSouth(SpaceNavigation location)
+        {
+            PeripheralItem periphery = new PeripheralItem(location);
+            periphery.Galaxies = _localDBService.GetLocalSubjects(location);
+
+            if (periphery.Galaxies.Count == 0)
+            {
+                periphery.Location = new SpaceNavigation(_localDBService.FindNextDescendingDec(location.MinDec));
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+            }
+            periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
+            return periphery;
+        }
+
+        private async Task<PeripheralItem> GetPeripheralEast(SpaceNavigation location)
+        {
+            PeripheralItem periphery = new PeripheralItem(location);
+            periphery.Galaxies = _localDBService.GetLocalSubjects(location);
+
+            if (periphery.Galaxies.Count == 0)
+            {
+                periphery.Location = new SpaceNavigation(_localDBService.FindNextDescendingRa(location.MinRa));
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+            }
+            periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
+            return periphery;
+        }
+
+        private async Task<PeripheralItem> GetPeripheralWest(SpaceNavigation location)
+        {
+            PeripheralItem periphery = new PeripheralItem(location);
+            periphery.Galaxies = _localDBService.GetLocalSubjects(location);
+
+            if (periphery.Galaxies.Count == 0)
+            {
+                periphery.Location = new SpaceNavigation(_localDBService.FindNextAscendingRa(location.MaxRa));
                 periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
             }
             periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -83,7 +83,7 @@ namespace GalaxyZooTouchTable.ViewModels
             Messenger.Default.Register<bool>(this, OnFlipCenterpiece, "TableStateChanged");
         }
 
-        private void LoadSpace()
+        public void LoadSpace()
         {
             CurrentLocation = new SpaceNavigation(_localDBService.GetRandomPoint());
             CurrentGalaxies = _localDBService.GetLocalSubjects(CurrentLocation, true);
@@ -150,7 +150,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnMoveViewWest(object obj)
         {
-            if (PeripheralItems.Northern == null) return;
+            if (PeripheralItems.Western == null) return;
             SpaceCutoutUrl = PeripheralItems.Western.Cutout;
             CurrentGalaxies = PeripheralItems.Western.Galaxies;
             if (CurrentGalaxies.Count > 0) AnimateMovement(CardinalDirectionEnum.West);
@@ -160,7 +160,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnMoveViewSouth(object obj)
         {
-            if (PeripheralItems.Northern == null) return;
+            if (PeripheralItems.Southern == null) return;
             SpaceCutoutUrl = PeripheralItems.Southern.Cutout;
             CurrentGalaxies = PeripheralItems.Southern.Galaxies;
             if (CurrentGalaxies.Count > 0) AnimateMovement(CardinalDirectionEnum.South);
@@ -170,7 +170,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnMoveViewEast(object obj)
         {
-            if (PeripheralItems.Northern == null) return;
+            if (PeripheralItems.Eastern == null) return;
             SpaceCutoutUrl = PeripheralItems.Eastern.Cutout;
             CurrentGalaxies = PeripheralItems.Eastern.Galaxies;
             if (CurrentGalaxies.Count > 0) AnimateMovement(CardinalDirectionEnum.East);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -4,6 +4,7 @@ using GalaxyZooTouchTable.Services;
 using GalaxyZooTouchTable.Utility;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -75,13 +76,25 @@ namespace GalaxyZooTouchTable.ViewModels
             _localDBService = localDBService;
             _cutoutService = cutoutService;
 
+            LoadSpace();
+            LoadCommands();
+            Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
+            Messenger.Default.Register<string>(this, OnShowError, "DatabaseError");
+            Messenger.Default.Register<bool>(this, OnFlipCenterpiece, "TableStateChanged");
+        }
+
+        private void LoadSpace()
+        {
             CurrentLocation = new SpaceNavigation(_localDBService.GetRandomPoint());
             CurrentGalaxies = _localDBService.GetLocalSubjects(CurrentLocation);
             SetSpaceCutout();
             SetPeripheralItems();
-            LoadCommands();
-            Messenger.Default.Register<ClassificationRingNotifier>(this, OnGalaxyInteraction);
-            Messenger.Default.Register<string>(this, OnShowError, "DatabaseError");
+        }
+
+        private void OnFlipCenterpiece(bool SpaceIsHidden)
+        {
+            if (SpaceIsHidden && CurrentGalaxies.All(subject=>subject.IsRetired))
+                LoadSpace();
         }
 
         private void OnGalaxyInteraction(ClassificationRingNotifier RingNotifier)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/SpaceViewModel.cs
@@ -86,7 +86,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void LoadSpace()
         {
             CurrentLocation = new SpaceNavigation(_localDBService.GetRandomPoint());
-            CurrentGalaxies = _localDBService.GetLocalSubjects(CurrentLocation);
+            CurrentGalaxies = _localDBService.GetLocalSubjects(CurrentLocation, true);
             SetSpaceCutout();
             SetPeripheralItems();
         }
@@ -211,7 +211,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (periphery.Galaxies.Count == 0)
             {
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextAscendingDec(location.MaxDec));
-                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location, true);
             }
             periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
             return periphery;
@@ -225,7 +225,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (periphery.Galaxies.Count == 0)
             {
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextDescendingDec(location.MinDec));
-                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location, true);
             }
             periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
             return periphery;
@@ -239,7 +239,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (periphery.Galaxies.Count == 0)
             {
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextDescendingRa(location.MinRa));
-                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location, true);
             }
             periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
             return periphery;
@@ -253,7 +253,7 @@ namespace GalaxyZooTouchTable.ViewModels
             if (periphery.Galaxies.Count == 0)
             {
                 periphery.Location = new SpaceNavigation(_localDBService.FindNextAscendingRa(location.MaxRa));
-                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location);
+                periphery.Galaxies = _localDBService.GetLocalSubjects(periphery.Location, true);
             }
             periphery.Cutout = await _cutoutService.GetSpaceCutout(periphery.Location);
             return periphery;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -46,11 +46,15 @@
 
         <Views:StillThereModal
             DataContext="{Binding StillThere}"
-            Panel.ZIndex="2"
+            Panel.ZIndex="3"
             Margin="108,20,128,0"/>
 
         <local:CloseConfirmation
             DataContext="{Binding CloseConfirmationViewModel}"
+            Panel.ZIndex="2"
+            Margin="108,20,128,0"/>
+
+        <Views:RetiredSubjectModal
             Panel.ZIndex="1"
             Margin="108,20,128,0"/>
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/GalaxyTileView.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
              xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
+             xmlns:Views="clr-namespace:GalaxyZooTouchTable.Views"
              mc:Ignorable="d" 
              x:Name="MainTile"
              RenderTransformOrigin="0.5,0.5"
@@ -15,6 +16,9 @@
 
             <Style.Triggers>
                 <DataTrigger Binding="{Binding Path=CurrentlyClassifying}" Value="False">
+                    <Setter Property="Opacity" Value="0.3"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Views:GalaxyTileView}}, Path=DataContext.IsRetired}" Value="True">
                     <Setter Property="Opacity" Value="0.3"/>
                 </DataTrigger>
             </Style.Triggers>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml
@@ -1,0 +1,87 @@
+﻿<UserControl x:Class="GalaxyZooTouchTable.Views.RetiredSubjectModal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:fa="http://schemas.fontawesome.io/icons/"
+             xmlns:Behaviors="clr-namespace:GalaxyZooTouchTable.Behaviors"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:Views="clr-namespace:GalaxyZooTouchTable.Views"
+             mc:Ignorable="d" 
+             Width="243"
+             Height="199"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <Style x:Key="CommonType" TargetType="{x:Type TextBlock}">
+            <Setter Property="FontFamily" Value="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+    </UserControl.Resources>
+
+    <Border Background="{StaticResource MedGrayColor}" CornerRadius="3">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="20" ShadowDepth="2"/>
+        </Border.Effect>
+        <Grid>
+            <Image
+                Source="../Images/General/Logo.png"
+                Height="14"
+                HorizontalAlignment="Left"
+                Margin="15,8,0,0"
+                VerticalAlignment="Top"/>
+
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
+                <i:Interaction.Behaviors>
+                    <Behaviors:TapBehavior Command="{Binding HideCloseConfirmation}"/>
+                </i:Interaction.Behaviors>
+                <TextBlock
+                    Style="{StaticResource CommonType}"
+                    FontSize="10"
+                    Margin="5,0"
+                    Text="Close"/>
+                <fa:ImageAwesome
+                    Foreground="White"
+                    Height="8.5"
+                    Icon="Times"/>
+            </StackPanel>
+
+            <Separator
+                Background="{StaticResource DarkGrayColor}"
+                Margin="0,29,0,0"
+                VerticalAlignment="Top"
+                Width="212"/>
+
+            <TextBlock
+                Text="This galaxy is ready to go"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                Foreground="White"
+                FontSize="17"
+                FontWeight="Bold"
+                Margin="0,44,0,0"
+                HorizontalAlignment="Center"/>
+
+            <TextBlock
+                Text="Thanks to people like you, this galaxy has had enough classifications that it's ready to be sent to the Galaxy Zoo database."
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                Foreground="White"
+                FontSize="9"
+                Margin="16,72,16,0"
+                TextWrapping="Wrap"
+                FontWeight="Bold"
+                HorizontalAlignment="Center"/>
+
+            <TextBlock
+                Text="Then scientists will use that information to study the universe."
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                Foreground="White"
+                FontSize="9"
+                Margin="20,122,20,0"
+                FontWeight="Bold"
+                TextWrapping="Wrap"
+                HorizontalAlignment="Center" Width="203"/>
+
+        </Grid>
+    </Border>
+</UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml
@@ -18,9 +18,19 @@
             <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
+
+        <Style x:Key="RetiredModal" TargetType="{x:Type Border}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding ShowRetirementModal}" Value="True">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
     </UserControl.Resources>
 
-    <Border Background="{StaticResource MedGrayColor}" CornerRadius="3">
+    <Border Style="{StaticResource RetiredModal}" Background="{StaticResource MedGrayColor}" CornerRadius="3">
         <Border.Effect>
             <DropShadowEffect BlurRadius="20" ShadowDepth="2"/>
         </Border.Effect>
@@ -34,7 +44,7 @@
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,15,0">
                 <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding HideCloseConfirmation}"/>
+                    <Behaviors:TapBehavior Command="{Binding HideRetirementModal}"/>
                 </i:Interaction.Behaviors>
                 <TextBlock
                     Style="{StaticResource CommonType}"
@@ -55,33 +65,43 @@
 
             <TextBlock
                 Text="This galaxy is ready to go"
-                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                Foreground="White"
+                Style="{StaticResource CommonType}"
                 FontSize="17"
-                FontWeight="Bold"
                 Margin="0,44,0,0"
                 HorizontalAlignment="Center"/>
 
             <TextBlock
                 Text="Thanks to people like you, this galaxy has had enough classifications that it's ready to be sent to the Galaxy Zoo database."
-                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                Foreground="White"
+                Style="{StaticResource CommonType}"
                 FontSize="9"
                 Margin="16,72,16,0"
                 TextWrapping="Wrap"
-                FontWeight="Bold"
                 HorizontalAlignment="Center"/>
 
             <TextBlock
                 Text="Then scientists will use that information to study the universe."
-                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
-                Foreground="White"
+                Style="{StaticResource CommonType}"
                 FontSize="9"
                 Margin="20,122,20,0"
-                FontWeight="Bold"
                 TextWrapping="Wrap"
                 HorizontalAlignment="Center" Width="203"/>
 
+            <Views:MultiTouchButton
+                Style="{StaticResource SubmitWithDownstate}"
+                Height="20"
+                HorizontalAlignment="Center"
+                Margin="0,0,0,14.59"
+                VerticalAlignment="Bottom"
+                Width="211"
+                PressCommand="{Binding HideRetirementModal}">
+                <TextBlock
+                    Style="{StaticResource CommonType}"
+                    FontSize="10"
+                    Foreground="Black"
+                    HorizontalAlignment="Center"
+                    Text="Choose another galaxy"
+                    VerticalAlignment="Center"/>
+            </Views:MultiTouchButton>
         </Grid>
     </Border>
 </UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace GalaxyZooTouchTable.Views
+{
+    /// <summary>
+    /// Interaction logic for RetiredSubjectModal.xaml
+    /// </summary>
+    public partial class RetiredSubjectModal : UserControl
+    {
+        public RetiredSubjectModal()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/RetiredSubjectModal.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace GalaxyZooTouchTable.Views
 {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml
@@ -21,6 +21,7 @@
             <Setter Property="CornerRadius" Value="3"/>
             <Setter Property="Background" Value="{StaticResource SuccessColor}"/>
             <Setter Property="Margin" Value="10"/>
+            <Setter Property="RenderTransformOrigin" Value="0.5,0.5"/>
         </Style>
 
         <Style x:Key="MoveMapText" TargetType="{x:Type TextBlock}">
@@ -98,58 +99,67 @@
                 </ItemsControl.ItemContainerStyle>
             </ItemsControl>
 
-            <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Top">
-                <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding MoveViewNorth}"/>
-                </i:Interaction.Behaviors>
-                <Border.LayoutTransform>
-                    <RotateTransform Angle="180"/>
-                </Border.LayoutTransform>
-                <StackPanel Orientation="Horizontal" Margin="10,0">
-                    <TextBlock Style="{StaticResource MoveMapText}"/>
-                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
-                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
-                </StackPanel>
+            <Border Height="55" Width="135" HorizontalAlignment="Left" VerticalAlignment="Top">
+                <Border x:Name="MoveMapNorth" Style="{StaticResource MoveMapBorder}">
+                    <i:Interaction.Behaviors>
+                        <Behaviors:TapBehavior Command="{Binding MoveViewNorth}"/>
+                    </i:Interaction.Behaviors>
+                    <Border.LayoutTransform>
+                        <RotateTransform Angle="180"/>
+                    </Border.LayoutTransform>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Style="{StaticResource MoveMapText}"/>
+                        <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                        <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Border>
             </Border>
 
-            <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Top">
-                <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding MoveViewEast}"/>
-                </i:Interaction.Behaviors>
-                <Border.LayoutTransform>
-                    <RotateTransform Angle="-90"/>
-                </Border.LayoutTransform>
-                <StackPanel Orientation="Horizontal" Margin="10,0">
-                    <TextBlock Style="{StaticResource MoveMapText}"/>
-                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
-                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
-                </StackPanel>
+            <Border Height="135" Width="55" HorizontalAlignment="Right" VerticalAlignment="Top">
+                <Border x:Name="MoveMapEast" Style="{StaticResource MoveMapBorder}">
+                    <i:Interaction.Behaviors>
+                        <Behaviors:TapBehavior Command="{Binding MoveViewEast}"/>
+                    </i:Interaction.Behaviors>
+                    <Border.LayoutTransform>
+                        <RotateTransform Angle="-90"/>
+                    </Border.LayoutTransform>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Style="{StaticResource MoveMapText}"/>
+                        <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                        <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Border>
             </Border>
 
-            <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Left" VerticalAlignment="Bottom">
-                <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding MoveViewWest}"/>
-                </i:Interaction.Behaviors>
-                <Border.LayoutTransform>
-                    <RotateTransform Angle="90"/>
-                </Border.LayoutTransform>
-                <StackPanel Orientation="Horizontal" Margin="10,0">
-                    <TextBlock Style="{StaticResource MoveMapText}"/>
-                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
-                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
-                </StackPanel>
+            <Border Width="55" Height="135" HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                <Border x:Name="MoveMapWest" Style="{StaticResource MoveMapBorder}">
+                    <i:Interaction.Behaviors>
+                        <Behaviors:TapBehavior Command="{Binding MoveViewWest}"/>
+                    </i:Interaction.Behaviors>
+                    <Border.LayoutTransform>
+                        <RotateTransform Angle="90"/>
+                    </Border.LayoutTransform>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Style="{StaticResource MoveMapText}"/>
+                        <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                        <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Border>
             </Border>
 
-            <Border Style="{StaticResource MoveMapBorder}" HorizontalAlignment="Right" VerticalAlignment="Bottom">
-                <i:Interaction.Behaviors>
-                    <Behaviors:TapBehavior Command="{Binding MoveViewSouth}"/>
-                </i:Interaction.Behaviors>
-                <StackPanel Orientation="Horizontal" Margin="10,0">
-                    <TextBlock Style="{StaticResource MoveMapText}"/>
-                    <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
-                    <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
-                </StackPanel>
+            <Border Width="135" Height="55" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                <Border x:Name="MoveMapSouth" Style="{StaticResource MoveMapBorder}">
+                    <i:Interaction.Behaviors>
+                        <Behaviors:TapBehavior Command="{Binding MoveViewSouth}"/>
+                    </i:Interaction.Behaviors>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Style="{StaticResource MoveMapText}"/>
+                        <fa:ImageAwesome Style="{StaticResource LoadingSpinner}" Icon="Refresh" Spin="True" Height="12" Width="12" Margin="10,0,0,0"/>
+                        <fa:ImageAwesome Style="{StaticResource DownArrow}" Icon="ArrowDown" Height="10" Width="10" Margin="10,0,0,0"/>
+                    </StackPanel>
+                </Border>
             </Border>
+            
             <StackPanel Style="{StaticResource ErrorPanel}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Orientation="Horizontal">
                 <TextBlock Text="{Binding ErrorMessage}" Foreground="Red"/>
                 <Button Content="X" Command="{Binding HideError}" Foreground="White" Background="Transparent" Margin="5,0" BorderThickness="0"/>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
@@ -24,6 +24,8 @@ namespace GalaxyZooTouchTable.Views
             ViewModel.AnimateMovement += AnimateCutoutMovement;
 
             Timer.Tick += new EventHandler(PulseGalaxies);
+            Timer.Tick += new EventHandler(PulseButtons);
+
             Timer.Interval = new TimeSpan(0, 0, 10);
             Timer.Start();
         }
@@ -31,6 +33,27 @@ namespace GalaxyZooTouchTable.Views
         private void PulseGalaxies(object sender, EventArgs e)
         {
             Messenger.Default.Send(sender, "Pulse_Galaxies");
+        }
+
+        private void PulseButtons(object sender, EventArgs e)
+        {
+            DoubleAnimation expandHeight = new DoubleAnimation(24, 32, TimeSpan.FromSeconds(0.75));
+            DoubleAnimation expandWidth = new DoubleAnimation(94, 110, TimeSpan.FromSeconds(0.75));
+            expandHeight.AutoReverse = expandWidth.AutoReverse = true;
+            expandHeight.RepeatBehavior = expandWidth.RepeatBehavior = new RepeatBehavior(2);
+            expandHeight.EasingFunction = expandWidth.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseIn };
+
+            MoveMapNorth.BeginAnimation(HeightProperty, expandHeight);
+            MoveMapNorth.BeginAnimation(WidthProperty, expandWidth);
+
+            MoveMapSouth.BeginAnimation(HeightProperty, expandHeight);
+            MoveMapSouth.BeginAnimation(WidthProperty, expandWidth);
+
+            MoveMapEast.BeginAnimation(HeightProperty, expandHeight);
+            MoveMapEast.BeginAnimation(WidthProperty, expandWidth);
+
+            MoveMapWest.BeginAnimation(HeightProperty, expandHeight);
+            MoveMapWest.BeginAnimation(WidthProperty, expandWidth);
         }
 
         void AnimateCutoutMovement(CardinalDirectionEnum direction)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
@@ -15,7 +15,8 @@ namespace GalaxyZooTouchTable.Views
     public partial class SpaceView : UserControl
     {
         SpaceViewModel ViewModel { get; set; }
-        DispatcherTimer Timer = new DispatcherTimer();
+        DispatcherTimer GalaxyPulseTimer = new DispatcherTimer();
+        DispatcherTimer MoveMapPulseTimer = new DispatcherTimer();
 
         public SpaceView()
         {
@@ -23,11 +24,13 @@ namespace GalaxyZooTouchTable.Views
             ViewModel = DataContext as SpaceViewModel;
             ViewModel.AnimateMovement += AnimateCutoutMovement;
 
-            Timer.Tick += new EventHandler(PulseGalaxies);
-            Timer.Tick += new EventHandler(PulseButtons);
+            GalaxyPulseTimer.Tick += new EventHandler(PulseGalaxies);
+            MoveMapPulseTimer.Tick += new EventHandler(PulseButtons);
 
-            Timer.Interval = new TimeSpan(0, 0, 10);
-            Timer.Start();
+            GalaxyPulseTimer.Interval = new TimeSpan(0, 0, 10);
+            MoveMapPulseTimer.Interval = new TimeSpan(0, 0, 10);
+            GalaxyPulseTimer.Start();
+            MoveMapPulseTimer.Start();
         }
 
         private void PulseGalaxies(object sender, EventArgs e)
@@ -162,8 +165,8 @@ namespace GalaxyZooTouchTable.Views
 
         private void ResetGalaxyPulseTimer(object sender, System.Windows.Input.TouchEventArgs e)
         {
-            Timer.Stop();
-            Timer.Start();
+            GalaxyPulseTimer.Stop();
+            GalaxyPulseTimer.Start();
         }
     }
 }


### PR DESCRIPTION
Describe your changes.
This PR brings in a modal that appears if a subject is retired (has hit 25 classifications). This _only_ occurs when dropping a subject into a classifier for a couple reasons.

- A user should always receive subjects with the lowest classification count when asking for a random subject. In the unlikely case all subjects are retired, I don't want to run into an infinite loop where no random subject can be retrieved because they're all retired and the modal is constantly shown since no subject can be retrieved.
- I think users should still be able to ask others at the table for advice on a subject, even if the subject is moving past retirement. There is no harm in a subject submitting more than 25 classifications to Panoptes, and users should still be able to interact with one another. 

Unrelated, I also removed the `IsOpen` variable from several `ExamplePanel` views, as that variable was no longer being used by the view model, or anything in particular.

Fixes #77 
Fixes #78 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
