### PR TITLE
Toggle intent

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/CloseConfirmationViewModel.cs
@@ -41,7 +41,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             Classifier = classifier;
             User = user;
-            CheckIntent = new CustomCommand(OnCheckIntent, CanCheckIntent);
+            CheckIntent = new CustomCommand(OnCheckIntent);
             ToggleCloseConfirmation = new CustomCommand(OnToggleCloseConfirmation);
             HideCloseConfirmation = new CustomCommand(OnHideCloseConfirmation);
             KeepClassifying = new CustomCommand(OnKeepClassifying);
@@ -69,7 +69,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnCheckIntent(object obj)
         {
-            Intent = true;
+            Intent = !Intent;
             LogEvent("Intent");
         }
 
@@ -77,11 +77,6 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             bool? show = visible as bool?;
             IsVisible = show ?? !IsVisible;
-        }
-
-        private bool CanCheckIntent(object obj)
-        {
-            return !Intent;
         }
 
         void LogEvent(string entry)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/CloseConfirmation.xaml
@@ -100,7 +100,7 @@
                 VerticalAlignment="Bottom"
                 Width="57"/>
 
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="15,0,0,42">
+            <StackPanel Background="Transparent" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="15,0,0,42">
                 <i:Interaction.Behaviors>
                     <Behaviors:TapBehavior Command="{Binding CheckIntent}"/>
                 </i:Interaction.Behaviors>


### PR DESCRIPTION
Describe your changes.
There is a bug where the intent button will not toggle on and off and only the text (not the checkbox) will trigger a selection.

To test this, open a classifier and then try to close it. The close confirmation window will appear and you'll see the checkbox showing user intent. With this fix, the user should be able to:

1. Trigger selection by tapping the box itself (and also the text aside it)
2. Toggle the checkbox on and off (filled and transparent) 

Fixes #80  .

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
