### PR TITLE
Fix queue bug

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/UIElementDragBehavior.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Behaviors/UIElementDragBehavior.cs
@@ -56,7 +56,8 @@ namespace GalaxyZooTouchTable.Behaviors
                 TouchPoint touchPosition = e.GetTouchPoint(DragOverlay);
                 Point initialPoint = new Point(touchPosition.Position.X, touchPosition.Position.Y);
                 FrameworkElement adornedElement = sender as FrameworkElement;
-                ConstructGhostAdornerWithHandlers(initialPoint, adornedElement, e);
+                if (initialPoint != null && adornedElement != null && e != null)
+                    ConstructGhostAdornerWithHandlers(initialPoint, adornedElement, e);
                 using (TableSubject subject = adornedElement.DataContext as TableSubject)
                     GlobalData.GetInstance().Logger?.AddEntry(entry: "Drag_Galaxy", subjectId: subject.Id);
             }
@@ -67,7 +68,9 @@ namespace GalaxyZooTouchTable.Behaviors
         {
             AdornerLayer adornerLayer = AdornerLayer.GetAdornerLayer(adornedElement);
             GalaxyAdorner adorner = new GalaxyAdorner(adornedElement, initialPoint);
-            adornerLayer.Add(adorner);
+            if (adornerLayer != null && adorner != null)
+                adornerLayer.Add(adorner);
+            else return;
 
             EventHandler<TouchEventArgs> moveHandler = new EventHandler<TouchEventArgs>((s, evt) => DragDropContainer_TouchMove(s, e, adorner));
             EventHandler<TouchEventArgs> upHandler = new EventHandler<TouchEventArgs>((s, evt) => DragDropContainer_TouchUp(s, evt, adorner, adornedElement));

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/ContainerHelper.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/ContainerHelper.cs
@@ -10,6 +10,7 @@ namespace GalaxyZooTouchTable.Lib
         static ContainerHelper()
         {
             _container = new UnityContainer();
+
             _container.RegisterType<IPanoptesService, PanoptesService>(
                 new ContainerControlledLifetimeManager());
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
@@ -11,22 +11,21 @@ namespace GalaxyZooTouchTable.Models
         private IGraphQLService _graphQLService;
         private IPanoptesService _panoptesService;
 
-        public ClassificationPanelViewModelFactory(IPanoptesService panoptesService, IGraphQLService graphQLService, ILocalDBService localDBService)
+        public ClassificationPanelViewModelFactory(IGraphQLService graphQLService, ILocalDBService localDBService)
         {
-            if (panoptesService == null || graphQLService == null || localDBService == null)
+            if (graphQLService == null || localDBService == null)
             {
                 throw new ArgumentNullException("RepoDependency");
             }
 
             _localDBService = localDBService;
             _graphQLService = graphQLService; 
-            _panoptesService = panoptesService;
         }
 
         public ClassificationPanelViewModel Create(UserType type)
         {
             TableUser User = AssignUser(type);
-            return new ClassificationPanelViewModel(_panoptesService, _localDBService, User);
+            return new ClassificationPanelViewModel(new PanoptesService(_localDBService), _localDBService, User);
         }
 
         private TableUser AssignUser(UserType type)

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -19,6 +19,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private ILocalDBService _localDBService;
         private List<CompletedClassification> CompletedClassifications { get; set; } = new List<CompletedClassification>();
         private DispatcherTimer StillThereTimer { get; set; } = new DispatcherTimer();
+        private bool IsSubmittingClassification;
 
         public Classification CurrentClassification { get; set; } = new Classification();
         public List<TableSubject> Subjects = new List<TableSubject>();
@@ -191,7 +192,12 @@ namespace GalaxyZooTouchTable.ViewModels
             OpenClassifier = new CustomCommand(OnOpenClassifier);
             SelectAnswer = new CustomCommand(OnSelectAnswer);
             ShowCloseConfirmation = new CustomCommand(OnShowCloseConfirmation);
-            SubmitClassification = new CustomCommand(OnSubmitClassification);
+            SubmitClassification = new CustomCommand(OnSubmitClassification, CanSubmitClassification);
+        }
+
+        private bool CanSubmitClassification(object obj)
+        {
+            return !IsSubmittingClassification;
         }
 
         private void OnShowCloseConfirmation(object obj)
@@ -249,6 +255,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private async void OnSubmitClassification(object sender)
         {
+            IsSubmittingClassification = true; 
             CurrentClassification.Annotations.Add(CurrentAnnotation);
             ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
             ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
@@ -258,6 +265,7 @@ namespace GalaxyZooTouchTable.ViewModels
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());
             OnChangeView(ClassifierViewEnum.SummaryView);
             HandleCompletedClassification();
+            IsSubmittingClassification = false;
         }
 
         void HandleCompletedClassification()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -257,6 +257,7 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             IsSubmittingClassification = true; 
             CurrentClassification.Annotations.Add(CurrentAnnotation);
+            HandleCompletedClassification();
             ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
             ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
 
@@ -264,12 +265,12 @@ namespace GalaxyZooTouchTable.ViewModels
             LevelerViewModel.OnIncrementCount();
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());
             OnChangeView(ClassifierViewEnum.SummaryView);
-            HandleCompletedClassification();
             IsSubmittingClassification = false;
         }
 
         void HandleCompletedClassification()
         {
+            if (SelectedAnswer == null || User == null || CurrentSubject == null) return;
             CompletedClassification FinishedClassification = new CompletedClassification(SelectedAnswer, User, CurrentSubject.Id);
             CompletedClassifications.Add(FinishedClassification);
             Messenger.Default.Send(FinishedClassification, $"{User.Name}_AddCompletedClassification");

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ExamplesPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ExamplesPanelViewModel.cs
@@ -10,7 +10,7 @@ namespace GalaxyZooTouchTable.ViewModels
         public ICommand SelectItem { get; private set; }
         public ICommand ToggleItem { get; private set; }
         public ICommand UnselectItem { get; private set; }
-        TableUser User { get; set; }
+        public TableUser User { get; set; }
 
         ClassificationPanelViewModel Classifier;
         public GalaxyExample Smooth { get; set; } = GalaxyExampleFactory.Create(GalaxyType.Smooth);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
@@ -317,8 +317,8 @@ namespace GalaxyZooTouchTable.ViewModels
                 NotificationPanel = new NotificationPanel(NotificationPanelStatus.ShowWarning);
                 return;
             }
-
-            PendingRequest Request = PendingRequests.First();
+            PendingRequest Request = PendingRequests.FirstOrDefault();
+            if (Request == null) return;
             Overlay = null;
             NotificationPanel = null;
             ChangeView(ClassifierViewEnum.SubjectView);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
@@ -318,9 +318,9 @@ namespace GalaxyZooTouchTable.ViewModels
                 return;
             }
             PendingRequest Request = PendingRequests.FirstOrDefault();
-            if (Request == null) return;
             Overlay = null;
             NotificationPanel = null;
+            if (Request == null) return;
             ChangeView(ClassifierViewEnum.SubjectView);
             GetSubjectById(Request.SubjectId);
             HelpNotification Notification = new HelpNotification(User, HelpNotificationStatus.Accepted);

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ExamplesPanel.xaml
@@ -90,9 +90,6 @@
                 <DataTrigger Binding="{Binding Path=Opacity, RelativeSource={RelativeSource Self}}" Value="0">
                     <Setter Property="Visibility" Value="Hidden"/>
                 </DataTrigger>
-                <DataTrigger Binding="{Binding Path=IsOpen}" Value="False">
-                    <Setter Property="Visibility" Value="Hidden"/>
-                </DataTrigger>
             </Style.Triggers>
         </Style>
 
@@ -279,9 +276,6 @@
                 <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
                     <Setter Property="Visibility" Value="Visible"/>
                 </DataTrigger>
-                <DataTrigger Binding="{Binding Path=IsOpen}" Value="False">
-                    <Setter Property="Visibility" Value="Hidden"/>
-                </DataTrigger>
             </Style.Triggers>
         </Style>
 
@@ -310,11 +304,6 @@
             <Setter Property="Width" Value="100"/>
             <Setter Property="Margin" Value="0"/>
             <Setter Property="Background" Value="{StaticResource DarkGrayColor}"/>
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=IsOpen}" Value="False">
-                    <Setter Property="Visibility" Value="Hidden"/>
-                </DataTrigger>
-            </Style.Triggers>
         </Style>
 
         <Style x:Key="HidingGridSeparators" BasedOn="{StaticResource GridSeparators}" TargetType="{x:Type Separator}">
@@ -337,16 +326,6 @@
             <Setter Property="Panel.ZIndex" Value="1"/>
             <Setter Property="Canvas.Top" Value="28"/>
             <Setter Property="Canvas.Left" Value="123"/>
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=IsOpen}" Value="True">
-                    <DataTrigger.EnterActions>
-                        <BeginStoryboard Storyboard="{StaticResource FadeOutStoryboard}"/>
-                    </DataTrigger.EnterActions>
-                    <DataTrigger.ExitActions>
-                        <BeginStoryboard Storyboard="{StaticResource FadeInStoryboard}"/>
-                    </DataTrigger.ExitActions>
-                </DataTrigger>
-            </Style.Triggers>
         </Style>
 
         <Style x:Key="ToggleText" BasedOn="{StaticResource ExampleText}" TargetType="{x:Type TextBlock}">


### PR DESCRIPTION
Describe your changes.
After deploying the table to the floor, a bug cropped up where the app will crash if the queued classifications are modified in place. This can happen two ways:

- A user double taps "submit classification" before their classification has been sent, resulting in the classification queue being added to while it is also being checked for classifications in a `foreach` loop.
- Two users click "submit classification" at the same time, resulting in the `PanoptesService` singleton (one instance) trying to modify the classification queue while it is being checked for a pending classification. This was remedied by giving each classifier its own `PanoptesService` instance and, thus, its own classification queue.

I also removed the `IsOpen` tag that is unnecessarily being referenced in the `ExamplesPanel` and the faulty `User.Name` binding in the same view.

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
