### PR TITLE
Correctly shutdown

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
@@ -5,6 +5,7 @@
              xmlns:ViewModels="clr-namespace:GalaxyZooTouchTable.ViewModels"
              xmlns:Converters="clr-namespace:GalaxyZooTouchTable.Converters"
              Startup="Application_Startup"
+             ShutdownMode="OnMainWindowClose"
              Exit="Application_Exit">
     <Application.Resources>
         <ResourceDictionary>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
@@ -5,8 +5,7 @@
              xmlns:ViewModels="clr-namespace:GalaxyZooTouchTable.ViewModels"
              xmlns:Converters="clr-namespace:GalaxyZooTouchTable.Converters"
              Startup="Application_Startup"
-             ShutdownMode="OnMainWindowClose"
-             Exit="Application_Exit">
+             ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml
@@ -5,7 +5,7 @@
              xmlns:ViewModels="clr-namespace:GalaxyZooTouchTable.ViewModels"
              xmlns:Converters="clr-namespace:GalaxyZooTouchTable.Converters"
              Startup="Application_Startup"
-             ShutdownMode="OnExplicitShutdown">
+             ShutdownMode="OnMainWindowClose">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -17,18 +17,13 @@ namespace GalaxyZooTouchTable
         {
             base.OnStartup(e);
 
-            var mainWindow = new MainWindow(new MainWindowViewModel());
+            Window mainWindow = new MainWindow(new MainWindowViewModel());
             mainWindow.Show();
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             GlobalData.GetInstance().EstablishLog();
-        }
-
-        private void Application_Exit(object sender, ExitEventArgs e)
-        {
-            GlobalData.GetInstance().Logger?.FinalizeLog();
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -27,7 +27,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>37</ApplicationRevision>
+    <ApplicationRevision>47</ApplicationRevision>
     <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -27,7 +27,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>47</ApplicationRevision>
+    <ApplicationRevision>54</ApplicationRevision>
     <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -27,7 +27,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>54</ApplicationRevision>
+    <ApplicationRevision>55</ApplicationRevision>
     <ApplicationVersion>1.1.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/Log.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Lib/Log.cs
@@ -85,10 +85,7 @@ namespace GalaxyZooTouchTable.Lib
                 // wait
             }
             WriteActiveBufferToFile();
-            while (writingInactiveBufferToFile)
-            {
-                // wait
-            }
+            WriteLinesToFile();
             Close();
         }
 
@@ -145,26 +142,31 @@ namespace GalaxyZooTouchTable.Lib
             }
         }
 
+        void WriteLinesToFile()
+        {
+            if (writingInactiveBufferToFile && isOpen)
+            {
+                foreach (String entry in inactiveEntryBuffer)
+                {
+                    log.WriteLine(entry);
+                }
+                inactiveEntryBuffer.Clear();
+                TimeSpan timeSinceLastCommit = DateTime.Now - lastCommitted;
+                if (timeSinceLastCommit > commitInterval)
+                {
+                    Close();
+                    Open();
+                    lastCommitted = DateTime.Now;
+                }
+                writingInactiveBufferToFile = false;
+            }
+        }
+
         public void WriteLoop()
         {
             while (true)
             {
-                if (writingInactiveBufferToFile && isOpen)
-                {
-                    foreach (String entry in inactiveEntryBuffer)
-                    {
-                        log.WriteLine(entry);
-                    }
-                    inactiveEntryBuffer.Clear();
-                    TimeSpan timeSinceLastCommit = DateTime.Now - lastCommitted;
-                    if (timeSinceLastCommit > commitInterval)
-                    {
-                        Close();
-                        Open();
-                        lastCommitted = DateTime.Now;
-                    }
-                    writingInactiveBufferToFile = false;
-                }
+                WriteLinesToFile();
                 Thread.Sleep(10000);
             }
         }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
@@ -34,7 +34,6 @@ namespace GalaxyZooTouchTable
             base.OnClosed(e);
 
             GlobalData.GetInstance().Logger?.FinalizeLog();
-            Application.Current.Dispatcher.InvokeShutdown();
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
+using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.ViewModels;
+using System;
 using System.Windows;
 using System.Windows.Input;
 
@@ -25,6 +27,14 @@ namespace GalaxyZooTouchTable
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
             _viewModel.Load();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+
+            GlobalData.GetInstance().Logger?.FinalizeLog();
+            Application.Current.Dispatcher.InvokeShutdown();
         }
     }
 }


### PR DESCRIPTION
Describe your changes.
Wow, this fixes a nasty bug. I was unaware a WPF app needs a defined `ShutdownMode`, or else the app will continue to run in the background after closed. This PR takes care of that, while also taking care of an issue with the logging thread.

The logging thread is set to run in the background while the app is open, but the app was closing before the thread had a chance to close. This causes the thread to continue running in the background on app close, which kept the app open even if a `ShutdownMode` is defined. Creating the `WriteLinesToFile` method explicitly closes the stream on app closure, thus allowing the app to close completely, even in the background.

Fixes #83  .

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
