### PR TITLE
Add Sentry for Error Reporting

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/app.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/app.config
@@ -21,6 +21,14 @@
         <assemblyIdentity name="SQLitePCLRaw.provider.e_sqlite3" publicKeyToken="9c301db686d0bd12" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
@@ -35,6 +35,10 @@
         <assemblyIdentity name="SQLitePCLRaw.provider.e_sqlite3" publicKeyToken="9c301db686d0bd12" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.13.388" newVersion="1.1.13.388" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using GalaxyZooTouchTable.Lib;
 using GalaxyZooTouchTable.ViewModels;
+using Sentry;
 using System;
 using System.Windows;
 
@@ -24,6 +25,18 @@ namespace GalaxyZooTouchTable
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             GlobalData.GetInstance().EstablishLog();
+        }
+
+        [STAThread]
+        public static void Main()
+        {
+            string dsn = Environment.GetEnvironmentVariable("SENTRY_DSN", EnvironmentVariableTarget.User);
+            using (SentrySdk.Init(dsn))
+            {
+                var application = new App();
+                application.InitializeComponent();
+                application.Run();
+            }
         }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -98,6 +98,15 @@
     <Reference Include="PanoptesNetClient, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PanoptesNetClient.1.1.2\lib\net461\PanoptesNetClient.dll</HintPath>
     </Reference>
+    <Reference Include="Sentry, Version=1.2.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.1.2.0\lib\net461\Sentry.dll</HintPath>
+    </Reference>
+    <Reference Include="Sentry.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.PlatformAbstractions.1.0.0\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Sentry.Protocol, Version=1.0.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sentry.Protocol.1.0.6\lib\net46\Sentry.Protocol.dll</HintPath>
+    </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.13.388, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.13\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
     </Reference>
@@ -108,6 +117,9 @@
       <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.13\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.ConfigurationManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -144,6 +156,11 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.5.9.0-RC\lib\net46\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
@@ -160,6 +177,7 @@
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\System.Windows.Interactivity.dll</HintPath>
@@ -184,10 +202,10 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
+    <Page Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
-    </ApplicationDefinition>
+    </Page>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationPanelViewModelFactory.cs
@@ -9,7 +9,6 @@ namespace GalaxyZooTouchTable.Models
     {
         private ILocalDBService _localDBService;
         private IGraphQLService _graphQLService;
-        private IPanoptesService _panoptesService;
 
         public ClassificationPanelViewModelFactory(IGraphQLService graphQLService, ILocalDBService localDBService)
         {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/packages.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/packages.config
@@ -8,12 +8,16 @@
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="PanoptesNetClient" version="1.1.2" targetFramework="net461" />
+  <package id="Sentry" version="1.2.0" targetFramework="net461" />
+  <package id="Sentry.PlatformAbstractions" version="1.0.0" targetFramework="net461" />
+  <package id="Sentry.Protocol" version="1.0.6" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.13" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.13" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.linux" version="1.1.13" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.13" targetFramework="net461" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.13" targetFramework="net461" />
   <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.13" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="4.4.1" targetFramework="net461" />
   <package id="System.Data.SQLite" version="1.0.110.0" targetFramework="net461" />
   <package id="System.Data.SQLite.Core" version="1.0.110.0" targetFramework="net461" />
@@ -26,6 +30,7 @@
   <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net461" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Likewise, the app can be installed via the same Google Drive File Stream locatio
 ## Log Files
 Log files are placed in a system's "Documents" folder under a "TouchTable_Logs" subdirectory. This should happen in debug and release builds, although logs are only committed in debug if the screen is X'ed out, as opposed to clicking "Stop Debugging" in Visual Studio.
 
+## Error Reporting
+The app is able to automatically report crashing errors to Sentry if a valid Sentry DSN is defined in the user's system environments under the variable `SENTRY_DSN`. If no environment variable is provided, the app will still run without error reporting.
+
 ## Offline First
 The app is set to run smoothly through temporary internet outages. When offline, finished classifications are placed in a queue and kept there until internet connection is established again. Internet connection is checked with each classification submitted, and queued classifications are submitted if internet is available. However, if the application is closed without internet access, all classifications held in the queue will be lost.
 


### PR DESCRIPTION
Describe your changes.
This PR allows the app to use [Sentry ](https://docs.sentry.io/error-reporting/quickstart/?platform=csharp) for automated error reporting. If a bug crashes the app, an email will be sent with the relevant error message and stack trace. This requires the app to use a Sentry wrapper at the entry point. A `SENTRY_DSN` env variable is also required on the system, which is explained in the README. The DSN value can be retrieved through Sentry.

**PLEASE MERGE THIS LAST**: I would like to test error reporting with an updated version of the app to ensure the current floor deploy is reporting as expected, especially as the entry point has changed.

Fixes # .

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
