### PR TITLE
Fix 96

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
@@ -334,8 +334,9 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             PendingRequest Request = PendingRequests.FirstOrDefault();
             HelpNotification Notification = new HelpNotification(User, HelpNotificationStatus.Decline);
-            Messenger.Default.Send(Notification, $"{Request.CooperatingPeer.Name}_PostNotification");
             ResetNotifications();
+            if (Request == null) return;
+            Messenger.Default.Send(Notification, $"{Request.CooperatingPeer.Name}_PostNotification");
             LogEvent(entry: "Decline_Galaxy", peer: Request.CooperatingPeer.Name);
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/NotificationsViewModel.cs
@@ -332,7 +332,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         void OnDeclineGalaxy(object sender)
         {
-            PendingRequest Request = PendingRequests.First();
+            PendingRequest Request = PendingRequests.FirstOrDefault();
             HelpNotification Notification = new HelpNotification(User, HelpNotificationStatus.Decline);
             Messenger.Default.Send(Notification, $"{Request.CooperatingPeer.Name}_PostNotification");
             ResetNotifications();


### PR DESCRIPTION
Describe your changes.
I'm not sure how `OnDeclineGalaxy` was triggered with no pending requests, but this PR adds the necessary failsafes to ensure a crash will not occur if that happens and the request collection is empty.

The fix was changing `.First` to `.FirstOrDefault` 
http://www.mukeshkumar.net/articles/linq/difference-between-first-and-firstordefault-in-linq

Fixes #96 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
