### PR TITLE
Minor observations

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/LevelerViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/LevelerViewModelTests.cs
@@ -53,21 +53,25 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
         {
             Assert.Equal("One", _viewModel.ClassificationLevel);
 
-            _viewModel.ClassificationsThisSession = 6;
+            _viewModel.ClassificationsThisSession = 5;
             _viewModel.ClassificationsUntilUpgrade = 0;
             Assert.Equal("Two", _viewModel.ClassificationLevel);
 
-            _viewModel.ClassificationsThisSession = 12;
+            _viewModel.ClassificationsThisSession = 10;
             _viewModel.ClassificationsUntilUpgrade = 0;
             Assert.Equal("Three", _viewModel.ClassificationLevel);
 
-            _viewModel.ClassificationsThisSession = 18;
+            _viewModel.ClassificationsThisSession = 15;
             _viewModel.ClassificationsUntilUpgrade = 0;
             Assert.Equal("Four", _viewModel.ClassificationLevel);
 
-            _viewModel.ClassificationsThisSession = 24;
+            _viewModel.ClassificationsThisSession = 20;
             _viewModel.ClassificationsUntilUpgrade = 0;
             Assert.Equal("Five", _viewModel.ClassificationLevel);
+
+            _viewModel.ClassificationsThisSession = 25;
+            _viewModel.ClassificationsUntilUpgrade = 0;
+            Assert.Equal("Master", _viewModel.ClassificationLevel);
         }
 
         [Fact]

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -53,10 +53,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>3F13CEEDA8A2CEE96FA4D0ECD0B5F57431DBABB9</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>D4A326B02C19A4F1BE50957DBF0F89E4A9E603EB</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>GalaxyZooTouchTable_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>
+    </ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateManifests>true</GenerateManifests>
@@ -388,9 +389,10 @@
     </None>
     <None Include="App.Release.config">
       <DependentUpon>App.config</DependentUpon>
+      <SubType>Designer</SubType>
     </None>
     <Resource Include="Fonts\Garamond.ttf" />
-    <None Include="GalaxyZooTouchTable_TemporaryKey.pfx" />
+    <None Include="GalaxyZooTouchTable_1_TemporaryKey.pfx" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -253,6 +253,7 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void OnOpenClassifier(object sender)
         {
+            Messenger.Default.Send(this, "New_User_Galaxy_Pulse");
             StartStillThereModalTimer();
             ClassifierOpen = true;
             User.Active = true;

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -284,9 +284,9 @@ namespace GalaxyZooTouchTable.ViewModels
             IsSubmittingClassification = true; 
             CurrentClassification.Annotations.Add(CurrentAnnotation);
             HandleCompletedClassification();
-            //ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
-            //ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
-            //if (counts.Total >= RETIRED_LIMIT) CurrentSubject.IsRetired = true;
+            ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
+            ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
+            if (counts.Total >= RETIRED_LIMIT) CurrentSubject.IsRetired = true;
             NotifySpaceView(RingNotifierStatus.IsSubmitting);
             LevelerViewModel.OnIncrementCount();
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -284,9 +284,9 @@ namespace GalaxyZooTouchTable.ViewModels
             IsSubmittingClassification = true; 
             CurrentClassification.Annotations.Add(CurrentAnnotation);
             HandleCompletedClassification();
-            ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
-            ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
-            if (counts.Total >= RETIRED_LIMIT) CurrentSubject.IsRetired = true;
+            //ClassificationCounts counts = await _panoptesService.CreateClassificationAsync(CurrentClassification);
+            //ClassificationSummaryViewModel.ProcessNewClassification(CurrentSubject.SubjectLocation, counts, CurrentAnswers, SelectedAnswer);
+            //if (counts.Total >= RETIRED_LIMIT) CurrentSubject.IsRetired = true;
             NotifySpaceView(RingNotifierStatus.IsSubmitting);
             LevelerViewModel.OnIncrementCount();
             GlobalData.GetInstance().Logger?.AddEntry("Submit_Classification", User.Name, CurrentSubject.Id, CurrentView, LevelerViewModel.ClassificationsThisSession.ToString());

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -310,7 +310,7 @@ namespace GalaxyZooTouchTable.ViewModels
         private void SetTimer()
         {
             StillThereTimer.Tick += new System.EventHandler(ShowStillThereModal);
-            StillThereTimer.Interval = new System.TimeSpan(0, 2, 30);
+            StillThereTimer.Interval = new System.TimeSpan(0, 1, 30);
         }
 
         public void StartStillThereModalTimer()

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
@@ -10,7 +10,7 @@ namespace GalaxyZooTouchTable.ViewModels
     {
         public TableUser User { get; set; }
         public ICommand ToggleLeveler { get; private set; }
-        private const string MAX_LEVEL = "Five";
+        private const string MAX_LEVEL = "Master";
         private const int DEFAULT_CLASSIFICATIONS_UNTIL_UPGRADE = 5;
         private const int DEFAULT_CLASSIFICATIONS_COUNT = 0;
         private const string DEFAULT_CLASSIFICATION_LEVEL = "One";
@@ -26,8 +26,9 @@ namespace GalaxyZooTouchTable.ViewModels
             {
                 if (value <= 0)
                 {
-                    value = 5;
                     LevelUp();
+                    if (ClassificationLevel != MAX_LEVEL)
+                        value = 5;
                 }
                 SetProperty(ref _classificationsUntilUpgrade, value);
             }
@@ -39,9 +40,11 @@ namespace GalaxyZooTouchTable.ViewModels
             get => _classificationsThisSession;
             set
             {
-                if (value != 0)
+                if (value != 0 && ClassificationLevel != MAX_LEVEL)
+                {
+                    SetProperty(ref _classificationsThisSession, value);
                     ClassificationsUntilUpgrade--;
-                SetProperty(ref _classificationsThisSession, value);
+                }
             }
         }
 
@@ -97,24 +100,24 @@ namespace GalaxyZooTouchTable.ViewModels
 
         private void LevelUp()
         {
+            if (ClassificationLevel == MAX_LEVEL) return;
             LevelUpAnimation();
             IsOpen = true;
-            if (ClassificationLevel == MAX_LEVEL)
-            {
-                return;
-            }
             switch (ClassificationsThisSession)
             {
-                case int n when (n <= 6):
+                case int n when (n <= 5):
                     ClassificationLevel = "Two";
                     break;
-                case int n when (n <= 12):
+                case int n when (n <= 10):
                     ClassificationLevel = "Three";
                     break;
-                case int n when (n <= 18):
+                case int n when (n <= 15):
                     ClassificationLevel = "Four";
                     break;
-                case int n when (n <= 24):
+                case int n when (n <= 20):
+                    ClassificationLevel = "Five";
+                    break;
+                case int n when (n <= 25):
                     ClassificationLevel = MAX_LEVEL;
                     break;
                 default:

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/ClassificationPanel.xaml
@@ -82,14 +82,16 @@
                 <StackPanel
                     Background="{StaticResource DarkGrayColor}"
                     HorizontalAlignment="Right"
-                    Margin="13,7"
+                    Height="25"
+                    Width="120"
+                    Margin="0,5,5,0"
                     Orientation="Horizontal"
                     VerticalAlignment="Top">
                     <i:Interaction.Behaviors>
                         <Behaviors:TapBehavior Command="{Binding ShowCloseConfirmation}"/>
                     </i:Interaction.Behaviors>
                     <TextBlock
-                        Margin="0,0,6,0"
+                        Margin="10,6"
                         FontSize="10"
                         Foreground="White"
                         VerticalAlignment="Center"

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Leveler.xaml
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/Leveler.xaml
@@ -12,6 +12,42 @@
              Height="88.35">
 
     <UserControl.Resources>
+        <Style x:Key="LeveledRank" TargetType="{x:Type TextBlock}">
+            <Setter Property="Visibility" Value="Visible"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=ClassificationLevel}" Value="Master">
+                    <Setter Property="Visibility" Value="Hidden"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="MasterRank" TargetType="{x:Type TextBlock}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=ClassificationLevel}" Value="Master">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="LeftToClassify" TargetType="{x:Type TextBlock}">
+            <Setter Property="Visibility" Value="Visible"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=ClassificationLevel}" Value="Master">
+                    <Setter Property="Visibility" Value="Hidden"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="ProStatus" TargetType="{x:Type TextBlock}">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=ClassificationLevel}" Value="Master">
+                    <Setter Property="Visibility" Value="Visible"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
         <Style x:Key="LevelerPanelStyle" TargetType="{x:Type Border}">
             <Style.Triggers>
                 <DataTrigger Binding="{Binding Path=IsOpen}" Value="False">
@@ -85,6 +121,7 @@
                 FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
 
             <TextBlock
+                Style="{StaticResource LeveledRank}"
                 Foreground="White"
                 FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
                 FontWeight="Bold"
@@ -95,6 +132,16 @@
             </TextBlock>
 
             <TextBlock
+                Style="{StaticResource MasterRank}"
+                Foreground="White"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"
+                FontWeight="Bold"
+                Margin="28.5,27.23,0,0"
+                FontSize="10.5"
+                Text="Master"/>
+
+            <TextBlock
+                Style="{StaticResource LeftToClassify}"
                 Foreground="White"
                 Margin="28.5,44.67,0,0"
                 FontSize="8"
@@ -104,6 +151,14 @@
                     <Run Text="more"/><LineBreak/>
                     <Run Text="Galaxies to level up."/>
             </TextBlock>
+
+            <TextBlock
+                Style="{StaticResource ProStatus}"
+                Foreground="White"
+                Margin="28.5,44.67,0,0"
+                Text="You're a Pro!"
+                FontSize="8"
+                FontFamily="/GalaxyZooTouchTable;component/Fonts/#Karla"/>
         </Grid>
     </Border>
 </UserControl>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Views/SpaceView.xaml.cs
@@ -31,6 +31,15 @@ namespace GalaxyZooTouchTable.Views
             MoveMapPulseTimer.Interval = new TimeSpan(0, 0, 10);
             GalaxyPulseTimer.Start();
             MoveMapPulseTimer.Start();
+
+            Messenger.Default.Register<object>(this, OnNewUserGalaxyPulse, "New_User_Galaxy_Pulse");
+        }
+
+        private void OnNewUserGalaxyPulse(object sender)
+        {
+            Messenger.Default.Send(sender, "Pulse_Galaxies");
+            GalaxyPulseTimer.Stop();
+            GalaxyPulseTimer.Start();
         }
 
         private void PulseGalaxies(object sender, EventArgs e)


### PR DESCRIPTION
Describe your changes.
This PR makes a few minor changes based on observations we've seen recently on the table. I can't quite close #94 yet as it'll be a substantial change to keep galaxies from disappearing when the map moves.

**Changes here**:
- Reduce classifier timeout to two minutes. Still here modal opens at 1m 30s and classifier closes after two minutes of inactivity.
- Pulse center galaxies whenever a new user joins the table.
- Expand the hit area of the "Close Classifier" button.
- Allow leveler to left side of classifier to max out at "Master" level right past level five.
- Adjust a bug where the leveler wouldn't increment correctly.

Fixes #29  .
Working towards #94 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
