### PR TITLE
Increment Bug

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/LevelerViewModelTests.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable.Tests/ViewModels/LevelerViewModelTests.cs
@@ -83,5 +83,14 @@ namespace GalaxyZooTouchTable.Tests.ViewModels
             Assert.True(_viewModel.IsOpen);
             Assert.True(LevelUpAnimationFired);
         }
+
+        [Fact]
+        public void ShouldResetClassificationCounts()
+        {
+            _viewModel.OnIncrementCount();
+            Assert.Equal(1, _viewModel.ClassificationsThisSession);
+            _viewModel.Reset();
+            Assert.Equal(0, _viewModel.ClassificationsThisSession);
+        }
     }
 }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -206,17 +206,15 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             CloseClassifier = new CustomCommand(OnCloseClassifier);
             TapDropZone = new CustomCommand(OnTapDropZone);
-            OpenClassifier = new CustomCommand(OnOpenClassifier);
+            OpenClassifier = new CustomCommand(OnOpenClassifier, CanOpenClassifier);
             SelectAnswer = new CustomCommand(OnSelectAnswer);
             ShowCloseConfirmation = new CustomCommand(OnShowCloseConfirmation);
             SubmitClassification = new CustomCommand(OnSubmitClassification, CanSubmitClassification);
             HideRetirementModal = new CustomCommand(OnHideRetirementModal);
         }
 
-        private bool CanSubmitClassification(object obj)
-        {
-            return !IsSubmittingClassification;
-        }
+        private bool CanOpenClassifier(object obj) { return !ClassifierOpen; }
+        private bool CanSubmitClassification(object obj) { return !IsSubmittingClassification; }
 
         private void OnHideRetirementModal(object obj)
         {

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/LevelerViewModel.cs
@@ -40,11 +40,9 @@ namespace GalaxyZooTouchTable.ViewModels
             get => _classificationsThisSession;
             set
             {
+                SetProperty(ref _classificationsThisSession, value);
                 if (value != 0 && ClassificationLevel != MAX_LEVEL)
-                {
-                    SetProperty(ref _classificationsThisSession, value);
                     ClassificationsUntilUpgrade--;
-                }
             }
         }
 


### PR DESCRIPTION
Describe your changes.
This small PR fixes a bug I noticed where classification counts were not resetting each time the classifier closed. The bug lasted three days, and I recorded the bug in the new Bug Log in the wiki. I added a test to ensure this doesn't happen again.

I also added a conditional in opening the classifier to make sure the classifier is closed before the method runs. This is to fix another bug in the logs where `Open_Classifier` would log several times from someone tapping the "Start" button repeatedly.

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?