### PR TITLE
Don't Show Classify Screen if Subject Retired

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -27,8 +27,8 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>5</ApplicationRevision>
-    <ApplicationVersion>1.2.2.%2a</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.2.4.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -395,7 +395,6 @@ namespace GalaxyZooTouchTable.ViewModels
         {
             GlobalData.GetInstance().Logger?.AddEntry("Drop_Galaxy", User.Name, subject.Id, CurrentView);
             if (CheckAlreadyCompleted(subject)) return;
-            if (CurrentView == ClassifierViewEnum.SummaryView) CurrentView = ClassifierViewEnum.SubjectView;
             if (subject.IsRetired)
             {
                 GlobalData.GetInstance().Logger?.AddEntry("Show_Retirement_Modal", User.Name, subject.Id, CurrentView);
@@ -405,6 +404,7 @@ namespace GalaxyZooTouchTable.ViewModels
             {
                 LoadSubject(subject);
                 NotifySpaceView(RingNotifierStatus.IsCreating);
+                CurrentView = ClassifierViewEnum.SubjectView;
             }
         }
 


### PR DESCRIPTION
Describe your changes.
Opening the retirement modal will not keep the classifier on the current state (showing answers or summary).

Fixes #112 

# Review Checklist

- [x] Are tests passing?
- [x] Is the build free of output errors?
