### PR TITLE
Refresh 2024: bump retirement to 25 and renew deploy process

### DIFF
--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/App.config
@@ -5,14 +5,14 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <appSettings>
-    <add key="Environment" value="Debug" />
-    <add key="ApiHost" value="https://panoptes-staging.zooniverse.org" />
-    <add key="ApplicationId" value="535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27" />
-    <add key="WorkflowId" value="3251" />
-    <add key="ProjectId" value="1857" />
+    <add key="Environment" value="Release" />
+    <add key="ApiHost" value="https://www.zooniverse.org" />
+    <add key="ApplicationId" value="f79cf5ea821bb161d8cbb52d061ab9a2321d7cb169007003af66b43f7b79ce2a" />
     <add key="StatsHost" value="https://stats.zooniverse.org" />
-    <add key="CaesarHost" value="https://caesar-staging.zooniverse.org/graphql" />
-    <add key="DatabaseName" value="GZ_Staging_Subjects.db" />
+    <add key="WorkflowId" value="11308" />
+    <add key="ProjectId" value="5733" />
+    <add key="CaesarHost" value="https://caesar.zooniverse.org/graphql" />
+    <add key="DatabaseName" value="GZ_Production_Subjects.db" />
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
@@ -52,6 +52,20 @@
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite.EF6" />
       <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
-    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+      <remove invariant="System.Data.SQLite" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+    </DbProviderFactories>
   </system.data>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/GalaxyZooTouchTable.csproj
@@ -17,7 +17,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <PublishUrl>G:\Shared drives\Citizen Science\Touch Table\</PublishUrl>
+    <PublishUrl>G:\Shared drives\Science Engagement\Touch Table\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
     <UpdateEnabled>false</UpdateEnabled>
@@ -28,7 +28,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.2.4.%2a</ApplicationVersion>
+    <ApplicationVersion>1.2.5.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
@@ -53,11 +53,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>D4A326B02C19A4F1BE50957DBF0F89E4A9E603EB</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>6A9B2AA2DA5B8A7CD0102507CBFA1BA40D6BA46E</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>
-    </ManifestKeyFile>
+    <ManifestKeyFile>GalaxyZooTouchTable_2_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateManifests>true</GenerateManifests>
@@ -179,6 +178,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\System.Windows.Interactivity.dll</HintPath>
@@ -412,7 +412,7 @@
       <SubType>Designer</SubType>
     </None>
     <Resource Include="Fonts\Garamond.ttf" />
-    <None Include="GalaxyZooTouchTable_1_TemporaryKey.pfx" />
+    <None Include="GalaxyZooTouchTable_2_TemporaryKey.pfx" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationSummary.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/ClassificationSummary.cs
@@ -9,7 +9,7 @@ namespace GalaxyZooTouchTable.Models
         public string SubjectLocation { get; private set; }
         public string SummaryString { get; private set; }
         public int TotalVotes { get; private set; }
-        public int VoteLimit { get; private set; } = 10;
+        public int VoteLimit { get; private set; } = 25;
 
         public ClassificationSummary(string subjectLocation, ClassificationCounts counts, List<AnswerButton> currentAnswers, AnswerButton selectedAnswer, string summaryString)
         {
@@ -18,7 +18,7 @@ namespace GalaxyZooTouchTable.Models
             SubjectLocation = subjectLocation;
             SummaryString = summaryString;
             TotalVotes = counts.Total;
-            if (TotalVotes > 10)
+            if (TotalVotes > 25)
                 VoteLimit = counts.Total;
         }
 

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Models/TableSubject.cs
@@ -10,7 +10,7 @@ namespace GalaxyZooTouchTable.Models
 {
     public class TableSubject : ViewModelBase,  IDisposable
     {
-        readonly int RETIRED_LIMIT = 10;
+        readonly int RETIRED_LIMIT = 25;
         SpaceNavigation CurrentLocation { get; set; }
         public int X { get; set; }
         public int Y { get; set; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/Services/LocalDBService.cs
@@ -12,7 +12,7 @@ namespace GalaxyZooTouchTable.Services
 {
     public class LocalDBService : ILocalDBService
     {
-        readonly int RETIREMENT_LIMIT = 10;
+        readonly int RETIREMENT_LIMIT = 25;
         readonly string QueuedSubjectsQuery = "select * from Subjects order by classifications_count asc, random() limit 10";
         readonly string QueuedSubjectQuery = "select * from Subjects order by classifications_count asc, random() limit 1";
         string HighestRaQuery(int limit) { return $"select * from Subjects where classifications_count < {limit} order by ra desc limit 1"; }

--- a/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
+++ b/GalaxyZooTouchTable/GalaxyZooTouchTable/ViewModels/ClassificationPanelViewModel.cs
@@ -15,7 +15,7 @@ namespace GalaxyZooTouchTable.ViewModels
 {
     public class ClassificationPanelViewModel : ViewModelBase
     {
-        readonly int RETIRED_LIMIT = 10;
+        readonly int RETIRED_LIMIT = 25;
         IPanoptesService _panoptesService;
         ILocalDBService _localDBService;
         List<CompletedClassification> CompletedClassifications { get; set; } = new List<CompletedClassification>();


### PR DESCRIPTION
# Overview
1. Bump subject retirement limit from 15 to 25 to restore ability for Adler visitors to drag-and-drop galaxies to work on.
    - Previous behavior: visitors needed to click the box for a random galaxy, as any dragged-and-dropped galaxy would prompt a "this galaxy is all finished, try again" pop-up message.
    - Solution: Revert changes made in #110 to restore retirement at 25 classifications.
2. The touch table hasn't been updated since Jan 2020 (!!!) so the previous deploy process needed to be updated. Updates to the wiki / docs will follow.
    - Minor Update - App.config file: I'm pretty sure App.config file needs `Release` values for final build, so those are updated in the main file here (even though Microsoft Visual Studio can choose from config files dynamically). Other additions (see `<system.web>` keys) are probably not necessary, but were included by VS.
    - Minor Update - GalaxyZooTouchTable.csproj file: These changes reflect a renewal of the app certificate, which is no longer a worry after this point (now expires in 2129; thanks to renewcert from OceanAirdrop/ExtendClickOnceCertificate).

# Review Checklist

- [X] Are tests passing?
- [X] Is the build free of output errors?

Note: build logs include a warning: `warning MSB3277: Found conflicts between different version of "System.ValueTuple" that could not be resolved.`; ignored.